### PR TITLE
Add --remindForum to toggle ability 

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,11 @@ var app = express();
 module.exports = app;
 
 nconf.env('__')
+    .argv({
+        'remindForum': {
+            describe: 'Enable forum-reminding ability'
+        }
+    })
     .file({
         file: 'config.json'
     });
@@ -112,11 +117,13 @@ webHookHandler.on('issues', function(repo, jsonResponse) { // eslint-disable-lin
             });
             break;
         case 'closed':
-            commentOnClosedIssue(commentsUrl).then(function(status) {
-                console.log('GitHub API returned with:', status);
-            }).catch(function(e) {
-                console.log('commentOnClosedIssue got an error:', e);
-            });
+            if (nconf.get('remindForum')) {
+                commentOnClosedIssue(commentsUrl).then(function(status) {
+                    console.log('GitHub API returned with:', status);
+                }).catch(function(e) {
+                    console.log('commentOnClosedIssue got an error:', e);
+                });
+            }
             break;
         default:
     }


### PR DESCRIPTION
Fixes #2 

This enables toggling the reminding "ability" of `cesium-concierge`. Three possible ways to use it (in order of decreasing power according to [nconf](https://github.com/indexzero/nconf)):

---
_Set environment variable `remindForum` to a non-empty value_, then
```bash
$ npm start
```

---
```bash
$ npm start -- --remindForum
$ npm start -- --no-remindForum
```

---
In `config.json`:
```javascript
{
  "remindForum": true // or false
}
```
---
As more abilities get implemented, we will enable toggles accordingly.