### PR TITLE
Fix coverage

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,12 @@
 'use strict';
 
 var Cesium = require('cesium');
+var child_process = require('child_process');
+var fsExtra = require('fs-extra');
 var gulp = require('gulp');
 var Jasmine = require('jasmine');
 var JasmineSpecReporter = require('jasmine-spec-reporter');
+var open = require('open');
 var yargs = require('yargs');
 
 var defined = Cesium.defined;
@@ -19,4 +22,21 @@ gulp.task('test', function (done) {
     jasmine.onComplete(function (passed) {
         done(argv.failTaskOnError && !passed ? 1 : 0);
     });
+});
+
+gulp.task('coverage', function() {
+    fsExtra.removeSync('coverage');
+
+    child_process.execSync('nyc' +
+        ' --all' +
+        ' --report-dir coverage/' +
+        ' -x "specs/**"' +
+        ' -x "coverage/**"' +
+        ' -x "gulpfile.js"' +
+        ' --reporter=lcov' +
+        ' node_modules/jasmine/bin/jasmine.js' +
+        ' JASMINE_CONFIG_PATH=specs/jasmine.json', {
+        stdio: [process.stdin, process.stdout, process.stderr]
+    });
+    open('coverage/lcov-report/index.html');
 });

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "eslint": "eslint . --cache",
     "start": "node index.js",
-    "coverage": "nyc gulp test",
+    "coverage": "gulp coverage",
     "test": "gulp test"
   }
 }


### PR DESCRIPTION
Implement coverage as we do in other repositories. It now opens `index.html` in the browser after running.

Uses [`nyc`](https://github.com/istanbuljs/nyc).