### PR TITLE
Replace RegexTools with one file per function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 'use strict';
 var bodyParser = require('body-parser');
 var express = require('express');
-var GitHubServer = require('./lib/GitHubServer');
 var gitHubWebHook = require('express-github-webhook');
 var nconf = require('nconf');
 var Promise = require('bluebird');
-var RegexTools = require('./lib/RegexTools');
+
+var GitHubServer = require('./lib/GitHubServer');
+var getGoogleGroupLinks = require('./lib/getGoogleGroupLinks');
 
 var app = express();
 module.exports = app;
@@ -45,7 +46,7 @@ function commentOnClosedIssue(commentsUrl) {
     return gitHubServer.get(commentsUrl)
     .then(function(commentsJsonResponse) {
         comments = GitHubServer.getCommentsFromResponse(commentsJsonResponse);
-        linkMatches = RegexTools.getGoogleGroupLinks(comments);
+        linkMatches = getGoogleGroupLinks(comments);
         if (linkMatches === []) {
             return Promise.reject('No google group links found in comments!');
         }

--- a/lib/getGoogleGroupLinks.js
+++ b/lib/getGoogleGroupLinks.js
@@ -1,0 +1,13 @@
+'use strict';
+var getUniqueMatch = require('./getUniqueMatch');
+
+/** Find unique GoogleGroup links in array of strings
+ *
+ * @param {String[]} textArray Array of strings to regex search
+ * @return {String[]} Unique links
+ */
+var googleLinkRegex = /https?:\/\/groups\.google\.com[^\s.,:]*/ig;
+
+module.exports = function getGoogleGroupLinks(textArray) {
+    return getUniqueMatch(textArray, googleLinkRegex);
+};

--- a/lib/getUniqueMatch.js
+++ b/lib/getUniqueMatch.js
@@ -2,20 +2,6 @@
 var Cesium = require('cesium');
 var defined = Cesium.defined;
 
-var RegexTools = {};
-module.exports = RegexTools;
-
-var googleLinkRegex = /https?:\/\/groups\.google\.com[^\s.,:]*/ig;
-
-/** Find unique GoogleGroup links in array of strings
- *
- * @param {String[]} textArray Array of strings to regex search
- * @return {String[]} Unique links
- */
-RegexTools.getGoogleGroupLinks = function(textArray) {
-    return RegexTools._getUniqueMatch(textArray, googleLinkRegex);
-};
-
 /** Generic regex search over array of String. (Requires global regex)
  *
  * @private
@@ -23,7 +9,7 @@ RegexTools.getGoogleGroupLinks = function(textArray) {
  * @param {Object} regex Global Regex
  * @returns {String[]} Unique matches of the regex
  */
-RegexTools._getUniqueMatch = function(textArray, regex) {
+module.exports = function getUniqueMatch(textArray, regex) {
     var matches = [];
     var matchResult;
     if (!defined(textArray) || !defined(regex)) {

--- a/specs/lib/getGoogleGroupLinksSpec.js
+++ b/specs/lib/getGoogleGroupLinksSpec.js
@@ -1,30 +1,8 @@
 'use strict';
-var RegexTools = require('../../lib/RegexTools');
 
-var getGoogleGroupLinks = RegexTools.getGoogleGroupLinks;
+var getGoogleGroupLinks = require('../../lib/getGoogleGroupLinks');
 
-describe('RegexTools._getUniqueMatch', function() {
-    var t1 = ['a', 'b', 'c', 'd'];
-    var t2 = ['a', 'a', 'b', 'bb', 'c', 'aaa', 'cab', 'c'];
-
-    it('returns [] when parameters are undefined', function() {
-        expect(RegexTools._getUniqueMatch()).toEqual([]);
-        expect(RegexTools._getUniqueMatch(['array'])).toEqual([]);
-    });
-
-    it('throws error if not passed an array', function() {
-        expect(function() {
-            RegexTools._getUniqueMatch('not array', /a/);
-        }).toThrowError(TypeError);
-    });
-
-    it('finds unique matches', function() {
-        expect(RegexTools._getUniqueMatch(t1, /[a-z]/g)).toEqual(t1);
-        expect(RegexTools._getUniqueMatch(t2, /[a-z]/g)).toEqual(['a', 'b', 'c']);
-    });
-});
-
-describe('RegexTools.getGoogleGroupLinks', function() {
+describe('getGoogleGroupLinks', function() {
     var comments = [];
     beforeEach(function() {
         comments = [

--- a/specs/lib/getUniqueMatchSpec.js
+++ b/specs/lib/getUniqueMatchSpec.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var getUniqueMatch = require('../../lib/getUniqueMatch');
+
+describe('getUniqueMatch', function() {
+    var t1 = ['a', 'b', 'c', 'd'];
+    var t2 = ['a', 'a', 'b', 'bb', 'c', 'aaa', 'cab', 'c'];
+
+    it('returns [] when parameters are undefined', function() {
+        expect(getUniqueMatch()).toEqual([]);
+        expect(getUniqueMatch(['array'])).toEqual([]);
+    });
+
+    it('throws error if not passed an array', function() {
+        expect(function() {
+            getUniqueMatch('not array', /a/);
+        }).toThrowError(TypeError);
+    });
+
+    it('finds unique matches', function() {
+        expect(getUniqueMatch(t1, /[a-z]/g)).toEqual(t1);
+        expect(getUniqueMatch(t2, /[a-z]/g)).toEqual(['a', 'b', 'c']);
+    });
+});


### PR DESCRIPTION
Remove `lib/RegexTools.js` in favor of files which export one function:
- `lib/getUniqueMatch.js`
- `lib/getGoogleGroupLinks.js`