### PR TITLE
Add `create-zip` gulp task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ npm-debug.log
 .idea/tasks.xml
 
 # Generated files
+build
 .eslintcache
 coverage
 *.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ npm-debug.log
 .idea/tasks.xml
 
 # Generated files
-build
 .eslintcache
 coverage
 *.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # NPM
 node_modules
 npm-debug.log
+npm-shrinkwrap.json
 
 # WebStorm user-specific
 .idea/workspace.xml

--- a/.npmignore
+++ b/.npmignore
@@ -10,4 +10,3 @@ gulpfile.js
 .eslintcache
 .eslintignore
 config.json
-/build

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ gulpfile.js
 .eslintcache
 .eslintignore
 config.json
+/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ dist: trusty
 script:
   - npm run eslint
   - npm run test
+  - npm run create-zip

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,8 +12,6 @@ var JasmineSpecReporter = require('jasmine-spec-reporter');
 var open = require('open');
 var yargs = require('yargs');
 
-var packageJson = require('./package.json');
-
 var defined = Cesium.defined;
 var argv = yargs.argv;
 
@@ -68,17 +66,12 @@ gulp.task('create-zip', function () {
             base: '.'
         });
 
-    //We don't run post install in production.
-    packageJson.version = packageJson.version + '-' + hash + '.0';
-    fsExtra.outputJsonSync('build/package.json', packageJson);
-
     child_process.execSync('npm shrinkwrap');
-    fsExtra.renameSync('npm-shrinkwrap.json', 'build/npm-shrinkwrap.json');
 
-    var packageFile = gulp.src('build/package.json');
-    var shrinkWrapFile = gulp.src('build/npm-shrinkwrap.json');
+    var packageJson = gulp.src('./package.json');
+    var shrinkWrapFile = gulp.src('npm-shrinkwrap.json');
 
-    return eventStream.merge(serverFiles, packageFile, shrinkWrapFile)
+    return eventStream.merge(serverFiles, packageJson, shrinkWrapFile)
         .pipe(gulpTap(function (file) {
             // Work around an issue with gulp-zip where archives generated on Windows do
             // not properly have their directory executable mode set.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,12 +2,17 @@
 
 var Cesium = require('cesium');
 var child_process = require('child_process');
+var eventStream = require('event-stream');
 var fsExtra = require('fs-extra');
 var gulp = require('gulp');
+var gulpTap = require('gulp-tap');
+var gulpZip = require('gulp-zip');
 var Jasmine = require('jasmine');
 var JasmineSpecReporter = require('jasmine-spec-reporter');
 var open = require('open');
 var yargs = require('yargs');
+
+var packageJson = require('./package.json');
 
 var defined = Cesium.defined;
 var argv = yargs.argv;
@@ -39,4 +44,49 @@ gulp.task('coverage', function () {
         stdio: [process.stdin, process.stdout, process.stderr]
     });
     open('coverage/lcov-report/index.html');
+});
+
+gulp.task('create-zip', function () {
+    var hash;
+    var status = child_process.execSync('git status -uno -s').toString().trim();
+    if (!/^\s*$/.test(status)) {
+        if (!argv.force) {
+            console.log('Refusing to create a release for a modified branch. Pass the --force flag if you know what you\'re doing.');
+            return;
+        }
+        hash = 'local-modifications';
+    } else {
+        hash = child_process.execSync('git rev-parse HEAD').toString().trim();
+    }
+
+    var zipName = 'cesium-concierge-' + hash + '.zip';
+
+    var serverFiles = gulp.src([
+            'lib/**',
+            'index.js'],
+        {
+            base: '.'
+        });
+
+    //We don't run post install in production.
+    packageJson.version = packageJson.version + '-' + hash + '.0';
+    fsExtra.outputJsonSync('build/package.json', packageJson);
+
+    child_process.execSync('npm shrinkwrap');
+    fsExtra.renameSync('npm-shrinkwrap.json', 'build/npm-shrinkwrap.json');
+
+    var packageFile = gulp.src('build/package.json');
+    var shrinkWrapFile = gulp.src('build/npm-shrinkwrap.json');
+
+    return eventStream.merge(serverFiles, packageFile, shrinkWrapFile)
+        .pipe(gulpTap(function (file) {
+            // Work around an issue with gulp-zip where archives generated on Windows do
+            // not properly have their directory executable mode set.
+            // see https://github.com/sindresorhus/gulp-zip/issues/64#issuecomment-205324031
+            if (file.isDirectory()) {
+                file.stat.mode = parseInt('40777', 8);
+            }
+        }))
+        .pipe(gulpZip(zipName))
+        .pipe(gulp.dest('.'));
 });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "cesium": "^1.35.1",
     "express": "^4.0.0",
     "express-github-webhook": "^1.0.6",
-    "fs-extra": "^3.0.0",
     "nconf": "^0.8.4",
     "request": "^2.81.0",
     "request-promise": "^4.2.1"
@@ -38,7 +37,12 @@
   "devDependencies": {
     "eslint": "^4.0.0",
     "eslint-config-cesium": "^2.0.0",
+    "event-stream": "^3.3.4",
+    "fs-extra": "^3.0.0",
     "gulp": "^3.9.1",
+    "gulp-rename": "^1.2.2",
+    "gulp-tap": "1.0.1",
+    "gulp-zip": "^4.0.0",
     "jasmine": "^2.6.0",
     "jasmine-spec-reporter": "^4.1.1",
     "nyc": "^11.0.3",
@@ -46,6 +50,7 @@
     "yargs": "^8.0.2"
   },
   "scripts": {
+    "create-zip": "gulp create-zip",
     "eslint": "eslint . --cache",
     "start": "node index.js",
     "coverage": "gulp coverage",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "event-stream": "^3.3.4",
     "fs-extra": "^3.0.0",
     "gulp": "^3.9.1",
-    "gulp-rename": "^1.2.2",
     "gulp-tap": "1.0.1",
     "gulp-zip": "^4.0.0",
     "jasmine": "^2.6.0",


### PR DESCRIPTION
Fixes #19 

Add wrapper around `npm shrinkwrap` in order to package `cesium-concierge` for deployment.

Tested by running the command, unzipping the generated file, and running `npm test` and `npm start` to verify things were working.

/cc @mramato look OK?