### PR TITLE
Fix google link regex to parse markdown link

### DIFF
--- a/lib/commentOnClosedIssue.js
+++ b/lib/commentOnClosedIssue.js
@@ -116,4 +116,4 @@ function statusCodeIsOk(response) {
     return false;
 }
 
-commentOnClosedIssue._googleLinkRegex = /https?:\/\/groups\.google\.com[^\s.,:]*/ig;
+commentOnClosedIssue._googleLinkRegex = /https?:\/\/groups\.google\.com[^\s.,:)\\]*/ig;

--- a/specs/lib/getUniqueMatchSpec.js
+++ b/specs/lib/getUniqueMatchSpec.js
@@ -35,6 +35,8 @@ describe('Google Group regex', function () {
     var commaAtEnd = 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test1, fdsfoewjaf fjdsa f';
     var twoLinks = 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test2, https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test5';
     var twoSameLinks = 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test2, https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test2, https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test3';
+    var markdownLink = 'This fixes #5446, also see this [forum post.](https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ)\\r\\n\\r\\nThis adds';
+    var returnAfterLink = 'https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ\\r\\n';
 
     it('Returns empty array for ""', function () {
         expect(getUniqueMatch([empty], googleLinkRegex)).toEqual([]);
@@ -60,5 +62,13 @@ describe('Google Group regex', function () {
         expect(getUniqueMatch([commaAtEnd], googleLinkRegex)).toEqual(['https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test1']);
         expect(getUniqueMatch([twoLinks], googleLinkRegex)).toEqual(['https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test2', 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test5']);
         expect(getUniqueMatch([twoSameLinks], googleLinkRegex)).toEqual(['https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test2', 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test3']);
+    });
+
+    it('Finds markdown link', function () {
+        expect(getUniqueMatch([markdownLink], googleLinkRegex)).toEqual(['https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ']);
+    });
+
+    it('Finds link with newline after', function () {
+        expect(getUniqueMatch([returnAfterLink], googleLinkRegex)).toEqual(['https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ']);
     });
 });


### PR DESCRIPTION
Huge oversight: the google group regex will not find google group links
- "embedded" in markdown
- followed by `\n` or `\r`

This fixes these cases and adds a unit test to confirm.