### PR TITLE
Don't run server as Docker root.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ EXPOSE 5000
 COPY . /var/app
 WORKDIR /var/app
 
+RUN useradd --no-log-init -m -g users concierge \
+  && chown -R concierge /var/app
+
+USER concierge:users
 RUN npm install
 
 ENTRYPOINT ["npm", "start"]


### PR DESCRIPTION
This is just a minor security best practice to not run as root in the Docker container in the off chance that a Docker escape/elevatione exploit it uncovered.