### PR TITLE
User crontab to correctly set up cron.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,24 +8,11 @@ RUN apt-get update \
   && apt-get -y install cron supervisor --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install
-
 COPY . /var/app
 WORKDIR /var/app
 
-COPY supervisord.conf /etc/supervisord.conf
+RUN npm install
 
-# Add crontab file in the cron directory
-ADD crontab /etc/cron.d/bumper-cron
+RUN crontab crontab
 
-# Give execution rights on the cron job
-RUN chmod 0644 /etc/cron.d/bumper-cron
-
-RUN touch /etc/crontab /etc/cron.*/* /var/log/cron.log
-
-# RUN useradd --no-log-init -m -g users concierge \
-#  && chown -R concierge /var/app
-
-# USER concierge:users
-
-ENTRYPOINT ["/usr/bin/supervisord"]
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/var/app/supervisord.conf"]

--- a/bin/stalePullRequest.js
+++ b/bin/stalePullRequest.js
@@ -21,10 +21,10 @@ if (require.main === module) {
 }
 /** Bump stale pull requests for each repository
  *
- * @param {String[]} repositoryNames Names of repositories
  * @returns {Promise<Array<http.IncomingMessage | undefined> | undefined>} Promise to an array of incoming messages
  */
-function stalePullRequest(repositoryNames) {
+function stalePullRequest() {
+    var repositoryNames = Object.keys(Settings.repositories);
     return Promise.all(
         repositoryNames.map(function (repositoryName) {
             var repositorySettings = Settings.repositories[repositoryName];

--- a/crontab
+++ b/crontab
@@ -1,2 +1,2 @@
-* * * * * root cd /var/app && /usr/local/bin/node bin/stalePullRequest.js >> /var/log/cron.log 2>&1
+* * * * * cd /var/app && /usr/local/bin/node bin/stalePullRequest.js >> /var/log/cron.log 2>&1
 # An empty line is required at the end of this file for a valid cron file.

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -14,7 +14,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:cron]
-command = cron -f -l 15
+command = cron -f -L 15
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,16 +1,23 @@
 [supervisord]
 nodaemon=true
-loglevel=debug
+loglevel=info
 
 [program:concierge]
 command=npm start
 directory=/var/app
 autostart=true
 autorestart=true
-redirect_stderr=false
 stopsignal = QUIT
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:cron]
-command = cron -f -L 15
+command = cron -f -l 15
 autostart=true
 autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
@omh1280 while I couldn't figure out the cron issue for non-root users (we'll just run root for now), I did find a bunch of issues with how you were setting up cron and made the following changes:

1. Rather than trying to set things up manually, use crontab to import the existing cron file as documented in the man page.
2. supervisord was running cron incorrectly, needed `-l` not `-L`.
3. Redirect all supervisord task output to stdout and stderr
4. Specify the supervisord configuration file directly rather than relying on putting it in `/etc`.
5. Remove unnecessary `root` specification in crontab.

Can you please test and merge.

Also, it looks like you have the task set up to run every minute, obviously that's far too often.  I assume once a day is probably enough.  Please make this change upstream after you review/test/merge this.

Thanks.