### PR TITLE
Use templates and external config for template values

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,26 @@ The possible settings are:
 | Name | Type | Description | Required? |
 | --- | --- | --- | --- |
 | `secret` | `string` | Repository secret to verify __incoming__ WebHook requests from GitHub | ✓
-| `repositories:{full_name}` | `object` | Settings specific to the repository `{full_name}`. | ✓
-| `repositories:{full_name}:gitHubToken` | `string` | Token used to verify __outgoing__ requests to GitHub repository | ✓
-| `repositories:{full_name}:remindForum` | `boolean` | Enables the functionality to post a reminder message to a closed issue if it contains links to a Google Group forum. | X
-| `repositories:{full_name}:thirdPartyFolders` | `string` | Comma-seperated list of folders in which to look for changed files in pull request to remind user to update License. | X
-| `repositories:{full_name}:checkChangesMd` | `boolean` | If `true`, check if `CHANGES.md` has been updated in pull request. If not, post comment suggesting that it should be edited. | X
-| `repositories:{full_name}:maxDaysSinceUpdate` | `number` | "Bump" pull requests older than this number of days ago | X
-| `port` | `number: default 5000` | Port on which to listen to incoming requests | X
 | `listenPath` | `string: default"/"` | Path on which to listen for incoming requests | X
+| `port` | `number: default 5000` | Port on which to listen to incoming requests | X
+| `repositories:{full_name}` | `object` | Settings specific to the repository `{full_name}`. | ✓
+
+Within the `repositories:{full_name}` object, there are these options:
+
+| Name | Type | Description | Required? |
+| --- | --- | --- | --- |
+| `gitHubToken` | `string` | Token used to verify __outgoing__ requests to GitHub repository | ✓
+| `remindForum` | `boolean` | Enables the functionality to post a reminder message to a closed issue if it contains links to a Google Group forum. | X
+| `thirdPartyFolders` | `string` | Comma-seperated list of folders in which to look for changed files in pull request to remind user to update License. | X
+| `checkChangesMd` | `boolean` | If `true`, check if `CHANGES.md` has been updated in pull request. If not, post comment suggesting that it should be edited. | X
+| `maxDaysSinceUpdate` | `number` | "Bump" pull requests older than this number of days ago | X
+| `signature` | `string` | _Part of comment:_ Last sentence in comment | X
+| `signature2` | `string` | _Part of comment:_ Last sentence in comment | X
+| `project` | `string` | _Part of comment:_ Name of project | X
+| `changesMarkdownLink` | `string` | _Part of comment:_ Markdown link to `CHANGES.md` or similar | X
+| `licenseMarkdownLink` | `string` | _Part of comment:_ Markdown link to `LICENSE.md` or similar | X
+| `guidelinesMarkdownLink` | `string` | _Part of comment:_ Markdown link to Guidelines document | X
+| `projectGitHub` | `string` | _Part of comment:_ GitHub link to Project Page | X
 
 > Note: `full_name` is the repository name in the form `{organization}/{repository}`. For example: `AnalyticalGraphicsInc/cesium`
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # cesium-concierge
 
-__Hello! I'm Cesium Conierge, a GitHub bot for [Cesium](https://github.com/AnalyticalGraphicsInc/cesium). I automate
-common certain GitHub tasks, and can currently:__
+__Hello! I'm Cesium Concierge, a GitHub bot for [Cesium](https://github.com/AnalyticalGraphicsInc/cesium). I automate
+common GitHub tasks, and can currently:__
 - Post a reminder comment to closed issues that have Google Group links in them
-- Post a suggestion to update `CHANGES.md` on newly-opened pull requests, and/or to update licenses if files in Third-party folders have changed.
+- Post a suggestion to update `CHANGES.md` on newly-opened pull requests, and/or to update licenses if files in Third-party folders have changed
+- Bump pull requests which have not been updated past a certain number of days 
+
 ## Building
 
 Clone this repository:

--- a/configDefault.json
+++ b/configDefault.json
@@ -1,0 +1,13 @@
+{
+  "repositories": {
+    "AnalyticalGraphicsInc/cesium": {
+      "project": "Cesium",
+      "changesMarkdownLink": "[CHANGES.md](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CHANGES.md)",
+      "signature": "__I am a bot who helps you make Cesium awesome!__ Thanks again.",
+      "licenseMarkdownLink": "[LICENSE.md](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md)",
+      "guidelinesMarkdownLink": "[Pull Request Guidelines](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#pull-request-guidelines)",
+      "projectGitHub": "https://github.com/AnalyticalGraphicsInc/cesium",
+      "signature2": "__I am a bot who helps facilitate your Cesium development!__ Thanks again for contributing."
+    }
+  }
+}

--- a/lib/commentOnClosedIssue.js
+++ b/lib/commentOnClosedIssue.js
@@ -3,10 +3,10 @@ var Cesium = require('cesium');
 var handlebars = require('handlebars');
 var Promise = require('bluebird');
 var requestPromise = require('request-promise');
-
 var dateLog = require('./dateLog');
-var getUniqueMatch = require('./getUniqueMatch');
+
 var checkStatus = require('./checkStatus');
+var getUniqueMatch = require('./getUniqueMatch');
 
 var Check = Cesium.Check;
 var defined = Cesium.defined;
@@ -18,31 +18,20 @@ var messageAfterLinks = '\nIf this issue affects any of these threads, please po
     '> The issue at {{ issueHtmlUrl }} has just been closed and may resolve your issue. Look for the change in the next stable release of {{ project }}!\n' +
     '> Or get it now in the master branch on GitHub {{ projectGitHub }}\n\n{{ signature }}';
 
-var project = 'Cesium';
-var signature = '__I am a bot who helps development running smoothly!__ Have a great day.';
-var projectGitHub = 'https://github.com/AnalyticalGraphicsInc/cesium';
-
 /** Post a comment on an issue/pull request that just closed, reminding the users to update Google Group forum links (if there
  * were any linked in the comments)
  *
  * @param {Object} jsonResponse GitHub Response for issue or pull_request (https://developer.github.com/v3/activity/events/types/#issuesevent)
  * @param {Object} headers Request headers
+ * @param {Object} templateObject Template object to populate strings
  * @return {Promise<http.IncomingMessage | String>} Response
  * @throws {DeveloperError} If `jsonResponse` or `headers` are not defined objects
  */
-function commentOnClosedIssue(jsonResponse, headers) {
+function commentOnClosedIssue(jsonResponse, headers, templateObject) {
     Check.typeOf.object('jsonResponse', jsonResponse);
     Check.typeOf.object('headers', headers);
-    var url;
-    var commentsUrl;
-    if (defined(jsonResponse.pull_request)) {
-        url = jsonResponse.pull_request.url;
-        commentsUrl = jsonResponse.pull_request.comments_url;
-    } else {
-        url = jsonResponse.issue.url;
-        commentsUrl = jsonResponse.issue.comments_url;
-    }
-    return commentOnClosedIssue._implementation(url, commentsUrl, headers);
+    var body = defined(jsonResponse.pull_request) ? jsonResponse.pull_request : jsonResponse.issue;
+    return commentOnClosedIssue._implementation(body.url, body.comments_url, headers, templateObject);
 }
 
 /** implementation
@@ -50,18 +39,17 @@ function commentOnClosedIssue(jsonResponse, headers) {
  * @param {String} issueUrl issue url
  * @param {String} commentsUrl comment url
  * @param {Object} headers headers
+ * @param {Object} templateObject Template object to populate strings
  * @private
  * @returns {Promise<http.IncomingMessage | String>} message response or string with error description
  */
-commentOnClosedIssue._implementation = function (issueUrl, commentsUrl, headers) {
+commentOnClosedIssue._implementation = function (issueUrl, commentsUrl, headers, templateObject) {
     var comments = [];
     var linkMatches = [];
     var issueHtmlUrl;
 
     return commentOnClosedIssue.get(issueUrl, headers)
-    .then(function (issueResponse) {
-        return checkStatus(issueResponse);
-    })
+    .then(checkStatus)
     .then(function (issueResponse) {
         issueHtmlUrl = issueResponse.body.html_url;
         comments.push(issueResponse.body.body);
@@ -69,9 +57,7 @@ commentOnClosedIssue._implementation = function (issueUrl, commentsUrl, headers)
     .then(function () {
         return commentOnClosedIssue.get(commentsUrl, headers);
     })
-    .then(function (commentsJsonResponse) {
-        return checkStatus(commentsJsonResponse);
-    })
+    .then(checkStatus)
     .then(function (commentsJsonResponse) {
         commentsJsonResponse.body.forEach(function (commentJson) {
             comments.push(commentJson.body);
@@ -89,12 +75,8 @@ commentOnClosedIssue._implementation = function (issueUrl, commentsUrl, headers)
         });
         message += messageAfterLinks;
         var template = handlebars.compile(message);
-        var finalMessage = template({
-            issueHtmlUrl: issueHtmlUrl,
-            project: project,
-            signature: signature,
-            projectGitHub: projectGitHub
-        });
+        templateObject.issueHtmlUrl = issueHtmlUrl;
+        var finalMessage = template(templateObject);
 
         return requestPromise.post({
             uri: commentsUrl,

--- a/lib/commentOnClosedIssue.js
+++ b/lib/commentOnClosedIssue.js
@@ -1,5 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
+var handlebars = require('handlebars');
 var Promise = require('bluebird');
 var requestPromise = require('request-promise');
 
@@ -11,6 +12,15 @@ var Check = Cesium.Check;
 var defined = Cesium.defined;
 
 module.exports = commentOnClosedIssue;
+
+var messageBeforeLinks = 'Congratulations on closing the issue! I found these {{ project }} forum links in the comments above:\n';
+var messageAfterLinks = '\nIf this issue affects any of these threads, please post a comment like the following:\n\n' +
+    '> The issue at {{ issueHtmlUrl }} has just been closed and may resolve your issue. Look for the change in the next stable release of {{ project }}!\n' +
+    '> Or get it now in the master branch on GitHub {{ projectGitHub }}\n\n{{ signature }}';
+
+var project = 'Cesium';
+var signature = '__I am a bot who helps development running smoothly!__ Have a great day.';
+var projectGitHub = 'https://github.com/AnalyticalGraphicsInc/cesium';
 
 /** Post a comment on an issue/pull request that just closed, reminding the users to update Google Group forum links (if there
  * were any linked in the comments)
@@ -73,16 +83,19 @@ commentOnClosedIssue._implementation = function (issueUrl, commentsUrl, headers)
         }
         dateLog('Found these links in the comments: ' + linkMatches);
 
-        var messageBeforeLinks = 'Congratulations on closing the issue! I found these Cesium forum links in the comments above:\n';
-        var messageAfterLinks = '\nIf this issue affects any of these threads, please post a comment like the following:\n\n' +
-            '> The issue at ' + issueHtmlUrl + ' has just been closed and may resolve your issue. Look for the change in the next stable release of Cesium!\n' +
-            '> Or get it now in the master branch on GitHub https://github.com/AnalyticalGraphicsInc/cesium\n\n' +
-            '__I am a bot who helps development running smoothly!__ Have a great day.';
-        var finalMessage = messageBeforeLinks;
+        var message = messageBeforeLinks;
         linkMatches.forEach(function(match) {
-            finalMessage += '- ' + match + '\n';
+            message += '- ' + match + '\n';
         });
-        finalMessage += messageAfterLinks;
+        message += messageAfterLinks;
+        var template = handlebars.compile(message);
+        var finalMessage = template({
+            issueHtmlUrl: issueHtmlUrl,
+            project: project,
+            signature: signature,
+            projectGitHub: projectGitHub
+        });
+
         return requestPromise.post({
             uri: commentsUrl,
             headers: headers,

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -14,17 +14,11 @@ var thankYouMessage = '@{{ user }} thanks for the pull request!\n\n';
 var changesMessage = 'I noticed that {{ changesMarkdownLink }} has not been updated. ' +
     'If this change updates the {{ project }} API in any way, fixes a bug, or makes any non-trivial update, please add ' +
     'a bullet point to `CHANGES.md` and bump this pull request so we know it was updated. ' +
-    'For more info, see the {{ guidelines }}.\n\n{{ signature }}';
+    'For more info, see the {{ guidelinesMarkdownLink }}.\n\n{{ signature }}';
 var thirdPartyMessage1 = 'I noticed that a file in ';
 var thirdPartyMessage2 = ' has been added or modified. ' +
     'Please verify that it has a section in {{ licenseMarkdownLink }} and that its license information is up to date with this new version. ' +
     'Once you do, please confirm by commenting on this pull request.\n\n{{ signature }}';
-
-var project = 'Cesium';
-var changesMarkdownLink = '[CHANGES.md](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CHANGES.md)';
-var signature = '__I am a bot who helps you make Cesium awesome!__ Thanks again.';
-var licenseMarkdownLink = '[LICENSE.md](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md)';
-var guidelines = '[Pull Request Guidelines](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#pull-request-guidelines)';
 
 module.exports = commentOnOpenedPullRequest;
 
@@ -36,16 +30,18 @@ var user = '';
  * @param {Object} headers Headers to use in GET requests
  * @param {String[]} thirdPartyFolders Folder paths to search for third party file changes
  * @param {Boolean} checkChangesMd If true, post about `CHANGES.md` not being updated
+ * @param {Object} templateObject Object to populate template strings
  * @return {Promise<http.IncomingMessage | String>} Response of POST
  * @throws {DeveloperError} if `jsonResponse`, `headers`, or `pullRequest` are not objects
  */
-function commentOnOpenedPullRequest(jsonResponse, headers, thirdPartyFolders, checkChangesMd) {
+function commentOnOpenedPullRequest(jsonResponse, headers, thirdPartyFolders, checkChangesMd, templateObject) {
     Check.typeOf.object('jsonResponse', jsonResponse);
     Check.typeOf.object('headers', headers);
     var pullRequest = jsonResponse.pull_request;
     Check.typeOf.object('pullRequest', pullRequest);
     user = jsonResponse.pull_request.user.login;
-    return commentOnOpenedPullRequest._implementation(pullRequest.url + '/files', pullRequest.comments_url, headers, thirdPartyFolders, checkChangesMd);
+    return commentOnOpenedPullRequest._implementation(pullRequest.url + '/files', pullRequest.comments_url, headers,
+        thirdPartyFolders, checkChangesMd, templateObject);
 }
 
 /** Implementation
@@ -55,10 +51,12 @@ function commentOnOpenedPullRequest(jsonResponse, headers, thirdPartyFolders, ch
  * @param {Object} headers Headers
  * @param {String[]} thirdPartyFolders Folder paths to search for third party file changes
  * @param {Boolean} checkChangesMd If true, post about `CHANGES.md` not being updated
+ * @param {Object} templateObject Object to populate template strings
  * @private
  * @return {Promise<http.IncomingMessage | String>} Response of POST
  */
-commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pullRequestCommentsUrl, headers, thirdPartyFolders, checkChangesMd) {
+commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pullRequestCommentsUrl, headers, thirdPartyFolders,
+                                                       checkChangesMd, templateObject) {
     return requestPromise.get({
         url: pullRequestFilesUrl,
         headers: headers,
@@ -83,19 +81,14 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
         var didUpdateChanges = commentOnOpenedPullRequest._didUpdateChanges(files);
         var didUpdateThirdParty = commentOnOpenedPullRequest._didUpdateThirdParty(files, thirdPartyFolders);
 
+        templateObject.user = user;
+
         if (!didUpdateChanges && checkChangesMd) {
             dateLog('CHANGES.md was updated');
             message = thankYouMessage + changesMessage;
 
             template = handlebars.compile(message);
-            finalMessage = template({
-                licenseMarkdownLink: licenseMarkdownLink,
-                signature: signature,
-                project: project,
-                changesMarkdownLink: changesMarkdownLink,
-                guidelines: guidelines,
-                user: user
-            });
+            finalMessage = template(templateObject);
             console.log(finalMessage);
             prom = prom.then(requestPromise.post({
                 uri: pullRequestCommentsUrl,
@@ -129,14 +122,7 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
             message += thirdPartyMessage2;
 
             template = handlebars.compile(message);
-            finalMessage = template({
-                licenseMarkdownLink: licenseMarkdownLink,
-                signature: signature,
-                project: project,
-                changesMarkdownLink: changesMarkdownLink,
-                guidelines: guidelines,
-                user: user
-            });
+            finalMessage = template(templateObject);
 
             prom = prom.then(requestPromise.post({
                 uri: pullRequestCommentsUrl,

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -1,5 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
+var handlebars = require('handlebars');
 var Promise = require('bluebird');
 var requestPromise = require('request-promise');
 
@@ -9,15 +10,21 @@ var checkStatus = require('./checkStatus');
 var Check = Cesium.Check;
 var defined = Cesium.defined;
 
-var thankYouMessage = ' thanks for the pull request!\n\n';
-var changesMessage = 'I noticed that [`CHANGES.md`](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CHANGES.md) has not been updated. ' +
-    'If this change updates the Cesium API in any way, fixes a bug, or makes any non-trivial update, please add a bullet point to `CHANGES.md` and bump this pull request so we know it was updated. ' +
-    'For more info, see the [Pull Request Guidelines]( https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#pull-request-guidelines).\n\n';
+var thankYouMessage = '@{{ user }} thanks for the pull request!\n\n';
+var changesMessage = 'I noticed that {{ changesMarkdownLink }} has not been updated. ' +
+    'If this change updates the {{ project }} API in any way, fixes a bug, or makes any non-trivial update, please add ' +
+    'a bullet point to `CHANGES.md` and bump this pull request so we know it was updated. ' +
+    'For more info, see the {{ guidelines }}.\n\n{{ signature }}';
 var thirdPartyMessage1 = 'I noticed that a file in ';
 var thirdPartyMessage2 = ' has been added or modified. ' +
-    'Please verify that it has a section in [LICENSE.md](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md) ' +
-    'and that its license information is up to date with this new version.  Once you do, please confirm by commenting on this pull request.\n\n';
-var thanksAgain = '__I am a bot who helps you make Cesium awesome!__ Thanks again.';
+    'Please verify that it has a section in {{ licenseMarkdownLink }} and that its license information is up to date with this new version. ' +
+    'Once you do, please confirm by commenting on this pull request.\n\n{{ signature }}';
+
+var project = 'Cesium';
+var changesMarkdownLink = '[CHANGES.md](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CHANGES.md)';
+var signature = '__I am a bot who helps you make Cesium awesome!__ Thanks again.';
+var licenseMarkdownLink = '[LICENSE.md](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md)';
+var guidelines = '[Pull Request Guidelines](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#pull-request-guidelines)';
 
 module.exports = commentOnOpenedPullRequest;
 
@@ -63,30 +70,38 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
     })
     .then(function (filesJsonResponse) {
         var message;
-        var files;
-        var didUpdateChanges;
-        var didUpdateThirdParty;
+        var finalMessage;
+        var template;
         var prom = Promise.resolve();
 
-        files = filesJsonResponse.body.map(function (file) {
+        var files = filesJsonResponse.body.map(function (file) {
             return file.filename;
         });
         dateLog('These files changed in the pull request: ' + files);
         dateLog('checkChangesMd is set to: ' + checkChangesMd);
 
-        didUpdateChanges = commentOnOpenedPullRequest._didUpdateChanges(files);
-        didUpdateThirdParty = commentOnOpenedPullRequest._didUpdateThirdParty(files, thirdPartyFolders);
+        var didUpdateChanges = commentOnOpenedPullRequest._didUpdateChanges(files);
+        var didUpdateThirdParty = commentOnOpenedPullRequest._didUpdateThirdParty(files, thirdPartyFolders);
 
         if (!didUpdateChanges && checkChangesMd) {
             dateLog('CHANGES.md was updated');
-            message = '@' + user + thankYouMessage;
-            message += changesMessage;
-            message += thanksAgain;
+            message = thankYouMessage + changesMessage;
+
+            template = handlebars.compile(message);
+            finalMessage = template({
+                licenseMarkdownLink: licenseMarkdownLink,
+                signature: signature,
+                project: project,
+                changesMarkdownLink: changesMarkdownLink,
+                guidelines: guidelines,
+                user: user
+            });
+            console.log(finalMessage);
             prom = prom.then(requestPromise.post({
                 uri: pullRequestCommentsUrl,
                 headers: headers,
                 body: {
-                    body: message
+                    body: finalMessage
                 },
                 json: true,
                 resolveWithFullResponse: true
@@ -94,7 +109,7 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
         }
         if (didUpdateThirdParty) {
             dateLog('A third party file changed');
-            message = '@' + user + thankYouMessage;
+            message = thankYouMessage;
             message += thirdPartyMessage1;
             switch (thirdPartyFolders.length) {
                 case 1:
@@ -112,12 +127,22 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
                     message += 'or `' + thirdPartyFolders[thirdPartyFolders.length - 1] + '`';
             }
             message += thirdPartyMessage2;
-            message += thanksAgain;
+
+            template = handlebars.compile(message);
+            finalMessage = template({
+                licenseMarkdownLink: licenseMarkdownLink,
+                signature: signature,
+                project: project,
+                changesMarkdownLink: changesMarkdownLink,
+                guidelines: guidelines,
+                user: user
+            });
+
             prom = prom.then(requestPromise.post({
                 uri: pullRequestCommentsUrl,
                 headers: headers,
                 body: {
-                    body: message
+                    body: finalMessage
                 },
                 json: true,
                 resolveWithFullResponse: true

--- a/lib/postToGitHub.js
+++ b/lib/postToGitHub.js
@@ -40,14 +40,23 @@ function postToGitHub(req, res, next) {
         repositorySettings.remindForum) {
         promise = promise.then(function () {
             dateLog('Calling commentOnClosedIssue');
-            return commentOnClosedIssue(req.body, headers);
+            return commentOnClosedIssue(req.body, headers, {
+                project: repositorySettings.project,
+                signature: repositorySettings.signature,
+                projectGitHub: repositorySettings.projectGitHub
+            });
         });
     } else if (event === 'pull_request' && action === 'opened' &&
         (defined(repositorySettings.thirdPartyFolders) || checkChangesMd)) {
         promise = promise.then(function () {
             dateLog('Calling commentOnOpenedPullRequest');
-            return commentOnOpenedPullRequest(req.body, headers, repositorySettings.thirdPartyFolders,
-                checkChangesMd);
+            return commentOnOpenedPullRequest(req.body, headers, repositorySettings.thirdPartyFolders, checkChangesMd, {
+                licenseMarkdownLink: repositorySettings.licenseMarkdownLink,
+                signature: repositorySettings.signature,
+                project: repositorySettings.project,
+                changesMarkdownLink: repositorySettings.changesMarkdownLink,
+                guidelines: repositorySettings.guidelines
+            });
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "body-parser": "^1.0.0",
     "cesium": "^1.35.1",
     "express": "^4.0.0",
+    "handlebars": "^4.0.10",
     "nconf": "^0.8.4",
     "request": "^2.81.0",
     "request-promise": "^4.2.1"

--- a/specs/data/responses/pullRequestCommentsNoConcierge.json
+++ b/specs/data/responses/pullRequestCommentsNoConcierge.json
@@ -1,0 +1,33 @@
+{
+  "statusCode": 200,
+  "body": [
+    {
+      "url": "https://api.github.com/repos/AnalyticalGraphicsInc/cesium-concierge/issues/comments/317763393",
+      "html_url": "https://github.com/AnalyticalGraphicsInc/cesium-concierge/pull/36#issuecomment-317763393",
+      "issue_url": "https://api.github.com/repos/AnalyticalGraphicsInc/cesium-concierge/issues/36",
+      "id": 317763393,
+      "user": {
+        "login": "omh1280",
+        "id": 1920134,
+        "avatar_url": "https://avatars1.githubusercontent.com/u/1920134?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/omh1280",
+        "html_url": "https://github.com/omh1280",
+        "followers_url": "https://api.github.com/users/omh1280/followers",
+        "following_url": "https://api.github.com/users/omh1280/following{/other_user}",
+        "gists_url": "https://api.github.com/users/omh1280/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/omh1280/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/omh1280/subscriptions",
+        "organizations_url": "https://api.github.com/users/omh1280/orgs",
+        "repos_url": "https://api.github.com/users/omh1280/repos",
+        "events_url": "https://api.github.com/users/omh1280/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/omh1280/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "created_at": "2017-07-25T14:53:07Z",
+      "updated_at": "2017-07-25T14:53:07Z",
+      "body": "Its English isn't the best.."
+    }
+  ]
+}

--- a/specs/lib/commentOnClosedIssueSpec.js
+++ b/specs/lib/commentOnClosedIssueSpec.js
@@ -27,14 +27,14 @@ describe('commentOnClosedIssue', function () {
         spyOn(commentOnClosedIssue, '_implementation');
         commentOnClosedIssue(fsExtra.readJsonSync('./specs/data/events/issue.json'), {test: true});
         expect(commentOnClosedIssue._implementation).toHaveBeenCalledWith('https://api.github.com/repos/baxterthehacker/public-repo/issues/2',
-            'https://api.github.com/repos/baxterthehacker/public-repo/issues/2/comments', {test: true});
+            'https://api.github.com/repos/baxterthehacker/public-repo/issues/2/comments', {test: true}, undefined);
     });
 
     it('passes correct pull request url and commentsUrl to _implementation', function () {
         spyOn(commentOnClosedIssue, '_implementation');
         commentOnClosedIssue(fsExtra.readJsonSync('./specs/data/events/pullRequest.json'), {test: true});
         expect(commentOnClosedIssue._implementation).toHaveBeenCalledWith('https://api.github.com/repos/baxterthehacker/public-repo/pulls/1',
-            'https://api.github.com/repos/baxterthehacker/public-repo/issues/1/comments', {test: true});
+            'https://api.github.com/repos/baxterthehacker/public-repo/issues/1/comments', {test: true}, undefined);
     });
 });
 
@@ -73,7 +73,7 @@ describe('commentOnClosedIssue._implementation', function () {
 
     it('calls requestPromise.post with correct values', function (done) {
         spyOn(getUniqueMatch, '_implementation').and.returnValue(['https://example.com']);
-        commentOnClosedIssue(issueEventJson, {test: true})
+        commentOnClosedIssue(issueEventJson, {test: true}, {})
             .then(function () {
                 var obj = requestPromise.post.calls.argsFor(0)[0];
                 expect(obj.uri).toEqual('https://api.github.com/repos/baxterthehacker/public-repo/issues/2/comments');
@@ -94,7 +94,7 @@ describe('commentOnClosedIssue._implementation detects bad statusCodes', functio
     it('returns rejected Promise if statusCode for issue !== 200', function (done) {
         spyOn(requestPromise, 'post');
         spyOn(commentOnClosedIssue, 'get').and.returnValue(Promise.resolve(issueJson404));
-        commentOnClosedIssue(issueEventJson, {test: true})
+        commentOnClosedIssue(issueEventJson, {test: true}, {})
         .then(function () {
             done.fail();
         })
@@ -111,7 +111,7 @@ describe('commentOnClosedIssue._implementation detects bad statusCodes', functio
             }
             return Promise.resolve(issueJson);
         });
-        commentOnClosedIssue(issueEventJson, {test: true})
+        commentOnClosedIssue(issueEventJson, {test: true}, {})
             .then(function () {
                 done.fail();
             })

--- a/specs/lib/commentOnOpenedPullRequestSpec.js
+++ b/specs/lib/commentOnOpenedPullRequestSpec.js
@@ -31,11 +31,11 @@ describe('commentOnOpenedPullRequest', function () {
         var pullRequestJson = fsExtra.readJsonSync('./specs/data/events/pullRequest.json');
         commentOnOpenedPullRequest(pullRequestJson, {}, [], false);
         expect(commentOnOpenedPullRequest._implementation).toHaveBeenCalledWith('https://api.github.com/repos/baxterthehacker/public-repo/pulls/1/files',
-            'https://api.github.com/repos/baxterthehacker/public-repo/issues/1/comments', {}, [], false);
+            'https://api.github.com/repos/baxterthehacker/public-repo/issues/1/comments', {}, [], false, undefined);
 
         commentOnOpenedPullRequest(pullRequestJson, {}, ['c'], true);
         expect(commentOnOpenedPullRequest._implementation).toHaveBeenCalledWith('https://api.github.com/repos/baxterthehacker/public-repo/pulls/1/files',
-            'https://api.github.com/repos/baxterthehacker/public-repo/issues/1/comments', {}, ['c'], true);
+            'https://api.github.com/repos/baxterthehacker/public-repo/issues/1/comments', {}, ['c'], true, undefined);
     });
 });
 
@@ -69,7 +69,7 @@ describe('commentOnOpenedPullRequest._implementation', function () {
         okPullRequest();
         spyOn(commentOnOpenedPullRequest, '_didUpdateChanges');
         spyOn(commentOnOpenedPullRequest, '_didUpdateThirdParty');
-        commentOnOpenedPullRequest._implementation()
+        commentOnOpenedPullRequest._implementation('', '', {}, ['specs/data/'], false, {})
             .then(function () {
                 expect(commentOnOpenedPullRequest._didUpdateChanges).toHaveBeenCalledWith(['.gitignore',
                     'index.js', 'lib/Settings.js', 'lib/commentOnClosedIssue.js', 'lib/getUniqueMatch.js',
@@ -80,7 +80,7 @@ describe('commentOnOpenedPullRequest._implementation', function () {
                     'index.js', 'lib/Settings.js', 'lib/commentOnClosedIssue.js', 'lib/getUniqueMatch.js',
                     'specs/data/config_noError.json', 'specs/data/config_noGitHubToken.json',
                     'specs/data/config_noRepositories.json', 'specs/data/config_noRepositoryNames.json',
-                    'specs/data/config_noSecret.json', 'specs/lib/SettingsSpec.js'], undefined);
+                    'specs/data/config_noSecret.json', 'specs/lib/SettingsSpec.js'], ['specs/data/']);
                 done();
             })
             .catch(function (err) {
@@ -90,7 +90,7 @@ describe('commentOnOpenedPullRequest._implementation', function () {
 
     it('Posts Third Party and CHANGES signature', function (done) {
         okPullRequest();
-        commentOnOpenedPullRequest._implementation('', '', {}, ['specs/data/'], true)
+        commentOnOpenedPullRequest._implementation('', '', {}, ['specs/data/'], true, {})
             .then(function () {
                 expect(/CHANGES/.test(requestPromise.post.calls.argsFor(0)[0].body.body)).toBe(true);
                 expect(/license/i.test(requestPromise.post.calls.argsFor(1)[0].body.body)).toBe(true);
@@ -103,7 +103,7 @@ describe('commentOnOpenedPullRequest._implementation', function () {
 
     it('Posts well-formatted English for two Third Party folders', function (done) {
         okPullRequest();
-        commentOnOpenedPullRequest._implementation('', '', {}, ['specs/data/', 'a/b/'], true)
+        commentOnOpenedPullRequest._implementation('', '', {}, ['specs/data/', 'a/b/'], true, {})
             .then(function () {
                 var obj = requestPromise.post.calls.argsFor(1)[0];
                 console.log(obj);
@@ -117,7 +117,7 @@ describe('commentOnOpenedPullRequest._implementation', function () {
 
     it('Posts well-formatted English for three Third Party folders', function (done) {
         okPullRequest();
-        commentOnOpenedPullRequest._implementation('', '', {}, ['specs/data/', 'a/b/', 'some/folder/'], true)
+        commentOnOpenedPullRequest._implementation('', '', {}, ['specs/data/', 'a/b/', 'some/folder/'], true, {})
             .then(function () {
                 var obj = requestPromise.post.calls.argsFor(1)[0];
                 console.log(obj);
@@ -131,7 +131,7 @@ describe('commentOnOpenedPullRequest._implementation', function () {
 
     it('Does not post CHANGES or Third Party signature', function (done) {
         spyOn(requestPromise, 'get').and.returnValue(Promise.resolve(pullRequestFilesWithChanges));
-        commentOnOpenedPullRequest._implementation('', '', {}, ['/some/folder'], true)
+        commentOnOpenedPullRequest._implementation('', '', {}, ['/some/folder'], true, {})
             .then(function () {
                 expect(requestPromise.post).toHaveBeenCalledTimes(0);
                 done();


### PR DESCRIPTION
Use [`handlebars`](http://handlebarsjs.com/) to clean up the messages using templating. The variable strings will eventually move into a configuration file and out of the source code.

What is the best way to specify the configurable strings like `signature` and `project`? Should they be in a `.js` file that looks like:

```javascript
var signature = 'blah';
var project = 'cesium';
...
```

Or should they be in `config.json`?