### PR TITLE
Adds support for CLA checking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The possible settings are:
 | `repositories:{full_name}` | `object` | Settings specific to the repository `{full_name}`. | ✓
 | `repositories:{full_name}:gitHubToken` | `string` | Token used to verify __outgoing__ requests to GitHub repository | ✓
 | `repositories:{full_name}:thirdPartyFolders` | `string` | Comma-separated list of folders in which to look for changed files in pull request to remind user to update License. | X
+| `repositories:{full_name}:claUrl` | `string` | The GitHub API URL to the CLA file in JSON form. If undefined it disables CLA checking. See [here](https://developer.github.com/v3/repos/contents/#get-contents) for how the URL should look. _Example:_ https://api.github.com/repos/AnalyticalGraphicsInc/cesium-concierge/contents/specs/data/config/CLA.json | X
 | `repositories:{full_name}:maxDaysSinceUpdate` | `number` | "Bump" pull requests older than this number of days ago | X
 | `port` | `number: default 5000` | Port on which to listen to incoming requests | X
 | `listenPath` | `string: default"/"` | Path on which to listen for incoming requests | X
@@ -51,6 +52,20 @@ The secret verifies that all incoming requests to your server are from GitHub an
 ### Setting `gitHubToken`
 Next, get a [Personal Access Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/), which verifies with GitHub that all requests to its API come from an account
 with privileges. Set it locally by using any of the three ways listed above.
+
+### CLA Format
+The `repositories:{full_name}:claUrl` should point to a GitHub URL of a JSON file with the following format:
+```json
+[
+  {
+    "gitHub": "user1"
+  },
+  {
+    "gitHub": "user2"
+  }
+]
+```
+The `gitHub` value is the only required field, but this format provides for storing more information alongside the GitHub name.
 
 ---
 

--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -83,6 +83,11 @@ function RepositorySettings(options) {
     this.secondaryStalePullRequestTemplate = handlebars.compile(defaultValue(options.secondaryStalePullRequestTemplate, defaultSecondaryStalePullRequest) + signature);
 
     /**
+     * Gets the URL of the CLA to use for this repository.
+     */
+    this.claUrl = options.claUrl;
+
+    /**
      * Gets the amount of days before a pull request is considered stale.
      */
     this.maxDaysSinceUpdate = defaultValue(options.maxDaysSinceUpdate, 30);

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -1,5 +1,6 @@
 'use strict';
 var Cesium = require('cesium');
+var Promise = require('bluebird');
 var requestPromise = require('request-promise');
 
 var Check = Cesium.Check;
@@ -30,11 +31,19 @@ function commentOnOpenedPullRequest(body, repositorySettings) {
 }
 
 commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, userName, repositoryUrl) {
-    return requestPromise.get({
-        url: pullRequestFilesUrl,
-        headers: repositorySettings.headers,
-        json: true
-    })
+    var claEnabled = defined(repositorySettings.claUrl);
+    var askForCla = false;
+    return commentOnOpenedPullRequest._askForCla(userName, repositorySettings)
+        .then(function (result) {
+            askForCla = result;
+        })
+        .then(function () {
+            return requestPromise.get({
+                url: pullRequestFilesUrl,
+                headers: repositorySettings.headers,
+                json: true
+            });
+        })
         .then(function (filesJsonResponse) {
             var files = filesJsonResponse.map(function (file) {
                 return file.filename;
@@ -46,6 +55,8 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
             var message = repositorySettings.pullRequestOpenedTemplate({
                 userName: userName,
                 repository_url: repositoryUrl,
+                claEnabled: claEnabled,
+                askForCla: askForCla,
                 askAboutChanges: askAboutChanges,
                 askAboutThirdParty: askAboutThirdParty,
                 thirdPartyFolders: repositorySettings.thirdPartyFolders.join(', ')
@@ -83,4 +94,26 @@ commentOnOpenedPullRequest._askAboutThirdParty = function (files, thirdPartyFold
         }
     }
     return false;
+};
+
+commentOnOpenedPullRequest._askForCla = function (username, repositorySettings) {
+    if (!defined(repositorySettings.claUrl)) {
+        return Promise.resolve(false);
+    }
+
+    return requestPromise.get({
+        url: repositorySettings.claUrl,
+        headers: repositorySettings.headers,
+        json: true
+    })
+        .then(function (response) {
+            var cla = JSON.parse(Buffer.from(response.content, 'base64').toString());
+            for (var i = 0; i < cla.length; i++) {
+                var claUsername = cla[i].gitHub;
+                if (defined(claUsername) && claUsername === username) {
+                    return false;
+                }
+            }
+            return true;
+        });
 };

--- a/lib/postToGitHub.js
+++ b/lib/postToGitHub.js
@@ -19,16 +19,12 @@ function postToGitHub(req, res, next) {
     var action = req.body.action;
     var event = req.headers['x-github-event'];
     var repositorySettings = Settings.repositories[repositoryName];
-    var headers = {
-        'User-Agent': 'cesium-concierge',
-        Authorization: 'token ' + repositorySettings.gitHubToken
-    };
 
     var promise;
     if ((event === 'issues' || event === 'pull_request') && action === 'closed') {
-        promise = postToGitHub._commentOnClosedIssue(req.body, headers);
+        promise = postToGitHub._commentOnClosedIssue(req.body, repositorySettings);
     } else if (event === 'pull_request' && action === 'opened') {
-        promise = postToGitHub._commentOnOpenedPullRequest(req.body, headers);
+        promise = postToGitHub._commentOnOpenedPullRequest(req.body, repositorySettings);
     } else {
         promise = Promise.resolve();
     }

--- a/lib/templates/pullRequestOpened.hbs
+++ b/lib/templates/pullRequestOpened.hbs
@@ -1,4 +1,14 @@
+{{#if claEnabled}}
+{{#if askForCla}}
+Welcome to the Cesium community @{{ userName }}!
+
+Can you please send in a [Contributor License Agreement](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla) (CLA) so that we can review and merge this pull request?
+{{else}}
+@{{ userName }}, thanks for the pull request! Maintainers, we have a signed CLA from @{{ userName }}, so you can review this at any time.
+{{/if}}
+{{else}}
 @{{ userName }}, thanks for the pull request!
+{{/if}}
 
 {{#if askAboutChanges}}
 I noticed that [CHANGES.md]({{ repository_url }}/blob/master/CHANGES.md) has not been updated. If this change updates the public API in any way, fixes a bug, or makes any non-trivial update, please add a bullet point to `CHANGES.md` and comment on this pull request so we know it was updated. For more info, see the [Pull Request Guidelines]( https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#pull-request-guidelines).

--- a/specs/lib/postToGitHubSpec.js
+++ b/specs/lib/postToGitHubSpec.js
@@ -3,11 +3,12 @@
 var Promise = require('bluebird');
 
 var postToGitHub = require('../../lib/postToGitHub');
+var RepositorySettings = require('../../lib/RepositorySettings');
 var Settings = require('../../lib/Settings');
 
 describe('postToGitHub', function () {
     var res;
-    var headers;
+    var repositorySettings;
 
     beforeEach(function () {
         res = {
@@ -17,17 +18,11 @@ describe('postToGitHub', function () {
             end: jasmine.createSpy('end')
         };
 
-        Settings.repositories['AnalyticalGraphics/cesium'] = {
-            gitHubToken: '123442345'
-        };
-
-        headers = {
-            'User-Agent': 'cesium-concierge',
-            Authorization: 'token 123442345'
-        };
+        repositorySettings = new RepositorySettings();
+        Settings.repositories['AnalyticalGraphics/cesium'] = repositorySettings;
     });
 
-    afterEach(function(){
+    afterEach(function () {
         delete Settings.repositories['AnalyticalGraphics/cesium'];
     });
 
@@ -63,7 +58,7 @@ describe('postToGitHub', function () {
 
         postToGitHub(req, res, next)
             .then(function () {
-                expect(postToGitHub._commentOnClosedIssue).toHaveBeenCalledWith(req.body, headers);
+                expect(postToGitHub._commentOnClosedIssue).toHaveBeenCalledWith(req.body, repositorySettings);
                 expect(res.status).toHaveBeenCalledWith(204);
                 expect(res.end).toHaveBeenCalled();
                 expect(next).toHaveBeenCalledWith();
@@ -90,7 +85,7 @@ describe('postToGitHub', function () {
 
         postToGitHub(req, res, next)
             .then(function () {
-                expect(postToGitHub._commentOnClosedIssue).toHaveBeenCalledWith(req.body, headers);
+                expect(postToGitHub._commentOnClosedIssue).toHaveBeenCalledWith(req.body, repositorySettings);
                 expect(res.status).toHaveBeenCalledWith(204);
                 expect(res.end).toHaveBeenCalled();
                 expect(next).toHaveBeenCalledWith();
@@ -117,7 +112,7 @@ describe('postToGitHub', function () {
 
         postToGitHub(req, res, next)
             .then(function () {
-                expect(postToGitHub._commentOnOpenedPullRequest).toHaveBeenCalledWith(req.body, headers);
+                expect(postToGitHub._commentOnOpenedPullRequest).toHaveBeenCalledWith(req.body, repositorySettings);
                 expect(res.status).toHaveBeenCalledWith(204);
                 expect(res.end).toHaveBeenCalled();
                 expect(next).toHaveBeenCalledWith();


### PR DESCRIPTION
The bot will always post a single message when a new PR is open and indicate whether the user has a CLA or not (so we can interpret the lack of a post as meaning something went wrong instead of assuming false
positive).

If claUrl is not configured, then we just thank them for the PR.

I configured this repository to use the Cesium CLA list, so we'll know right away if this works.