### PR TITLE
Adjust forum regex to only match forum posts

### DIFF
--- a/lib/commentOnClosedIssue.js
+++ b/lib/commentOnClosedIssue.js
@@ -85,4 +85,4 @@ commentOnClosedIssue._implementation = function (issueUrl, commentsUrl, reposito
         });
 };
 
-commentOnClosedIssue._googleLinkRegex = /https?:\/\/groups\.google\.com[^\s.,:)\\]*/ig;
+commentOnClosedIssue._googleLinkRegex = /https?:\/\/groups\.google\.com\/forum\/(\?\w+=\w+)?#!(topic|msg)\/cesium-dev\/(\w+\/?)+/ig;

--- a/lib/commentOnClosedIssue.js
+++ b/lib/commentOnClosedIssue.js
@@ -85,4 +85,4 @@ commentOnClosedIssue._implementation = function (issueUrl, commentsUrl, reposito
         });
 };
 
-commentOnClosedIssue._googleLinkRegex = /https?:\/\/groups\.google\.com\/forum\/(\?\w+=\w+)?#!(topic|msg)\/cesium-dev\/(\w+\/?)+/ig;
+commentOnClosedIssue._googleLinkRegex = /https?:\/\/groups\.google\.com\/[^\s.,:)\\]*cesium-dev\/[^\s.,:)\\]+/ig;

--- a/specs/lib/getUniqueMatchSpec.js
+++ b/specs/lib/getUniqueMatchSpec.js
@@ -31,8 +31,6 @@ describe('Google Group regex', function () {
     var noLink = 'this has no google link';
     var sslLink = 'https://groups.google.com/forum/#!topic/cesium-dev/Wd0P0EnFDjA';
     var noSslLink = 'http://groups.google.com/forum/#!topic/cesium-dev/Wd0P0EnFDjA';
-    var queryLink = 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/Wd0P0EnFDjA';
-    var msgLink = 'https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ';
     var surroundedText = 'Reported here: https://groups.google.com/forum/?hl=en#!topic/cesium-dev/fewafjdsk\n\nSeen with Chrome 59.0.3071.102. iOS version: 10.3.2. Perhaps a driver issue?\n';
     var commaAtEnd = 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test1, fdsfoewjaf fjdsa f';
     var twoLinks = 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test2, https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test5';
@@ -40,7 +38,7 @@ describe('Google Group regex', function () {
     var markdownLink = 'This fixes #5446, also see this [forum post.](https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ)\\r\\n\\r\\nThis adds';
     var returnAfterLink = 'https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ\\r\\n';
     var baseLink = 'https://groups.google.com/forum/!forum/cesium-dev';
-    var baseLinkWithLanguage = 'https://groups.google.com/forum/?hl=en#!forum/cesium-dev';
+    var baseLink2 = 'https://groups.google.com/forum/?hl=en#!forum/cesium-dev';
 
     it('Returns empty array for ""', function () {
         expect(getUniqueMatch([empty], googleLinkRegex)).toEqual([]);
@@ -76,15 +74,7 @@ describe('Google Group regex', function () {
         expect(getUniqueMatch([returnAfterLink], googleLinkRegex)).toEqual(['https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ']);
     });
 
-    it('Matches urls with and without language query', function () {
-        expect(getUniqueMatch([sslLink, queryLink], googleLinkRegex)).toEqual([sslLink, queryLink]);
-    });
-
-    it('Matches both "topic" and "msg" links', function () {
-        expect(getUniqueMatch([sslLink, msgLink], googleLinkRegex)).toEqual([sslLink, msgLink]);
-    });
-
     it('Doesn\'t match links to base forum', function () {
-        expect(getUniqueMatch([baseLink, baseLinkWithLanguage], googleLinkRegex)).toEqual([]);
+        expect(getUniqueMatch([baseLink, baseLink2], googleLinkRegex)).toEqual([]);
     });
 });

--- a/specs/lib/getUniqueMatchSpec.js
+++ b/specs/lib/getUniqueMatchSpec.js
@@ -29,14 +29,18 @@ describe('getUniqueMatch', function () {
 describe('Google Group regex', function () {
     var empty = '';
     var noLink = 'this has no google link';
-    var sslLink = 'https://groups.google.com/';
-    var noSslLink = 'http://groups.google.com/';
+    var sslLink = 'https://groups.google.com/forum/#!topic/cesium-dev/Wd0P0EnFDjA';
+    var noSslLink = 'http://groups.google.com/forum/#!topic/cesium-dev/Wd0P0EnFDjA';
+    var queryLink = 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/Wd0P0EnFDjA';
+    var msgLink = 'https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ';
     var surroundedText = 'Reported here: https://groups.google.com/forum/?hl=en#!topic/cesium-dev/fewafjdsk\n\nSeen with Chrome 59.0.3071.102. iOS version: 10.3.2. Perhaps a driver issue?\n';
     var commaAtEnd = 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test1, fdsfoewjaf fjdsa f';
     var twoLinks = 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test2, https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test5';
     var twoSameLinks = 'https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test2, https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test2, https://groups.google.com/forum/?hl=en#!topic/cesium-dev/test3';
     var markdownLink = 'This fixes #5446, also see this [forum post.](https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ)\\r\\n\\r\\nThis adds';
     var returnAfterLink = 'https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ\\r\\n';
+    var baseLink = 'https://groups.google.com/forum/!forum/cesium-dev';
+    var baseLinkWithLanguage = 'https://groups.google.com/forum/?hl=en#!forum/cesium-dev';
 
     it('Returns empty array for ""', function () {
         expect(getUniqueMatch([empty], googleLinkRegex)).toEqual([]);
@@ -70,5 +74,17 @@ describe('Google Group regex', function () {
 
     it('Finds link with newline after', function () {
         expect(getUniqueMatch([returnAfterLink], googleLinkRegex)).toEqual(['https://groups.google.com/forum/#!msg/cesium-dev/Ktn8aPQmOsQ/_Dbd7igkCQAJ']);
+    });
+
+    it('Matches urls with and without language query', function () {
+        expect(getUniqueMatch([sslLink, queryLink], googleLinkRegex)).toEqual([sslLink, queryLink]);
+    });
+
+    it('Matches both "topic" and "msg" links', function () {
+        expect(getUniqueMatch([sslLink, msgLink], googleLinkRegex)).toEqual([sslLink, msgLink]);
+    });
+
+    it('Doesn\'t match links to base forum', function () {
+        expect(getUniqueMatch([baseLink, baseLinkWithLanguage], googleLinkRegex)).toEqual([]);
     });
 });


### PR DESCRIPTION
Fixes #61

Only matches threads or message links to the `cesium-dev` forum.

