### PR TITLE
Load repository settings from the github repo

### DIFF
--- a/.concierge/templates/signature.hbs
+++ b/.concierge/templates/signature.hbs
@@ -1,0 +1,3 @@
+---
+
+:sparkles: :sparkles: :sparkles:__I'm the Cesium Concierge and I'm here to test things.__ :sparkles: :sparkles: :sparkles:

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="JavaScriptLibraryMappings">
-    <includedPredefinedLibrary name="Node.js Core" />
+    <file url="file://$PROJECT_DIR$" libraries="{cesium-concierge node_modules}" />
   </component>
 </project>

--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -5,16 +5,17 @@ var fs = require('fs');
 var handlebars = require('handlebars');
 var path = require('path');
 
+var loadRepoConfig = require('./loadRepoConfig');
+
 var defined = Cesium.defined;
 var defaultValue = Cesium.defaultValue;
-
-module.exports = RepositorySettings;
 
 var defaultInitialStalePullRequest = fs.readFileSync(path.join(__dirname, 'templates', 'initialStalePullRequest.hbs')).toString();
 var defaultIssueClosed = fs.readFileSync(path.join(__dirname, 'templates', 'issueClosed.hbs')).toString();
 var defaultPullRequestOpened = fs.readFileSync(path.join(__dirname, 'templates', 'pullRequestOpened.hbs')).toString();
 var defaultSecondaryStalePullRequest = fs.readFileSync(path.join(__dirname, 'templates', 'secondaryStalePullRequest.hbs')).toString();
 var defaultSignature = fs.readFileSync(path.join(__dirname, 'templates', 'signature.hbs')).toString();
+var defaultMaxDaysSinceUpdate = 30;
 
 /**
  * Encapsulate available options for each repository.
@@ -22,65 +23,21 @@ var defaultSignature = fs.readFileSync(path.join(__dirname, 'templates', 'signat
  * @constructor
  */
 function RepositorySettings(options) {
-
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
-    var thirdPartyFolders = options.thirdPartyFolders;
-    if (defined(thirdPartyFolders)) {
-        var thirdPartyFoldersArray = thirdPartyFolders.split(',');
-        for (var j = 0; j < thirdPartyFoldersArray.length; j++) {
-            var folder = thirdPartyFoldersArray[j];
-            if (folder.startsWith('/')) {
-                thirdPartyFoldersArray[j] = folder.slice(1);
-            }
-            if (!folder.endsWith('/')) {
-                thirdPartyFoldersArray[j] = folder + '/';
-            }
-        }
-        thirdPartyFolders = thirdPartyFoldersArray;
-    }
-
-    var signature = '\n\n' + defaultValue(options.signature, defaultSignature);
-
-    /**
-     * Gets the headers to use for authenticated GitHub requests.
-     * @type {Object}
-     */
-    this.headers = {
+    this._name = options.name;
+    this._gitHubToken = options.gitHubToken;
+    this._headers = {
         'User-Agent': 'cesium-concierge',
         Authorization: 'token ' + options.gitHubToken
     };
 
-    /**
-     * Gets the access token for this repository.
-     * @type {String}
-     */
-    this.gitHubToken = options.gitHubToken;
-
-    /**
-     * Gets the array of third party source files.
-     */
-    this.thirdPartyFolders = defaultValue(thirdPartyFolders, []);
-
-    /**
-     * Gets the handlebars template to use when commenting on a closed issue.
-     */
-    this.issueClosedTemplate = handlebars.compile(defaultValue(options.issueClosedTemplate, defaultIssueClosed) + signature);
-
-    /**
-     * Gets the handlebars template to use when commenting on a new pull request.
-     */
-    this.pullRequestOpenedTemplate = handlebars.compile(defaultValue(options.pullRequestOpenedTemplate, defaultPullRequestOpened) + signature);
-
-    /**
-     * Gets the handlebars template to use when commenting on a stale pull request for the first time.
-     */
-    this.initialStalePullRequestTemplate = handlebars.compile(defaultValue(options.initialStalePullRequestTemplate, defaultInitialStalePullRequest) + signature);
-
-    /**
-     * Gets the handlebars template to use when commenting on a stale pull request for the second time.
-     */
-    this.secondaryStalePullRequestTemplate = handlebars.compile(defaultValue(options.secondaryStalePullRequestTemplate, defaultSecondaryStalePullRequest) + signature);
+    this.thirdPartyFolders = defaultValue(options.thirdPartyFolders, []);
+    this.signature = defaultValue(options.signature, defaultSignature);
+    this.issueClosedTemplate = defaultValue(options.issueClosedTemplate, defaultIssueClosed);
+    this.pullRequestOpenedTemplate = defaultValue(options.pullRequestOpenedTemplate, defaultPullRequestOpened);
+    this.initialStalePullRequestTemplate = defaultValue(options.initialStalePullRequestTemplate, defaultInitialStalePullRequest);
+    this.secondaryStalePullRequestTemplate = defaultValue(options.secondaryStalePullRequestTemplate, defaultSecondaryStalePullRequest);
 
     /**
      * Gets the URL of the CLA to use for this repository.
@@ -90,5 +47,139 @@ function RepositorySettings(options) {
     /**
      * Gets the amount of days before a pull request is considered stale.
      */
-    this.maxDaysSinceUpdate = defaultValue(options.maxDaysSinceUpdate, 30);
+    this.maxDaysSinceUpdate = defaultValue(options.maxDaysSinceUpdate, defaultMaxDaysSinceUpdate);
 }
+
+Object.defineProperties(RepositorySettings.prototype, {
+    /**
+     * Gets the name of the repository
+     * @type {String}
+     */
+    name: {
+        get: function () {
+            return this._name;
+        }
+    },
+
+    /**
+     * Gets the headers to use for authenticated GitHub requests.
+     * @type {Object}
+     */
+    headers: {
+        get: function () {
+            return this._headers;
+        }
+    },
+
+    /**
+     * Gets the access token for this repository.
+     * @type {String}
+     */
+    gitHubToken: {
+        get: function () {
+            return this._gitHubToken;
+        }
+    },
+
+    /**
+     * Gets the array of third party source files.
+     * @type {String[]}
+     */
+    thirdPartyFolders: {
+        get: function () {
+            return this._thirdPartyFolders;
+        },
+        set: function (value) {
+            var thirdPartyFolders = value;
+            if (typeof value === 'string') {
+                var thirdPartyFoldersArray = value.split(',');
+                for (var j = 0; j < thirdPartyFoldersArray.length; j++) {
+                    var folder = thirdPartyFoldersArray[j];
+                    if (folder.startsWith('/')) {
+                        thirdPartyFoldersArray[j] = folder.slice(1);
+                    }
+                    if (!folder.endsWith('/')) {
+                        thirdPartyFoldersArray[j] = folder + '/';
+                    }
+                }
+                thirdPartyFolders = thirdPartyFoldersArray;
+            }
+            this._thirdPartyFolders = thirdPartyFolders;
+        }
+    },
+
+    /**
+     * Gets the raw template for the signature at the bottom of each comment template.
+     * @type {String}
+     */
+    signature: {
+        get: function () {
+            return '\n\n' + this._signature;
+        },
+        set: function (value) {
+            this._signature = value;
+        }
+    },
+
+    /**
+     * Gets the handlebars template to use when commenting on a closed issue.
+     * @type {String}
+     */
+    issueClosedTemplate: {
+        get: function () {
+            return handlebars.compile(this._issueClosedTemplate + this.signature);
+        },
+        set: function (value) {
+            this._issueClosedTemplate = value;
+        }
+    },
+
+    /**
+     * Gets the handlebars template to use when commenting on a new pull request.
+     * @type {String}
+     */
+    pullRequestOpenedTemplate: {
+        get: function () {
+            return handlebars.compile(this._pullRequestOpenedTemplate+ this.signature);
+        },
+        set: function (value) {
+            this._pullRequestOpenedTemplate = value;
+        }
+    },
+
+    /**
+     * Gets the handlebars template to use when commenting on a stale pull request for the first time.
+     * @type {String}
+     */
+    initialStalePullRequestTemplate: {
+        get: function () {
+            return handlebars.compile(this._initialStalePullRequestTemplate + this.signature);
+        },
+        set: function (value) {
+            this._initialStalePullRequestTemplate = value;
+        }
+    },
+
+    /**
+     * Gets the handlebars template to use when commenting on a stale pull request for the second time.
+     * @type {String}
+     */
+    secondaryStalePullRequestTemplate: {
+        get: function () {
+            return handlebars.compile(this._secondaryStalePullRequestTemplate + this.signature);
+        },
+        set: function (value) {
+            this._secondaryStalePullRequestTemplate = value;
+        }
+    }
+});
+
+/**
+ * Requests the latest version of the configuration settings from the repository.
+ * @returns {Promise<Object|String>} A Promise that resolves with the new configuration, or the error message if the Promise fails.
+ */
+RepositorySettings.prototype.fetchSettings = function () {
+    return loadRepoConfig(this.name, this.headers, this);
+};
+
+module.exports = RepositorySettings;

--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -7,7 +7,6 @@ var path = require('path');
 
 var loadRepoConfig = require('./loadRepoConfig');
 
-var defined = Cesium.defined;
 var defaultValue = Cesium.defaultValue;
 
 var defaultInitialStalePullRequest = fs.readFileSync(path.join(__dirname, 'templates', 'initialStalePullRequest.hbs')).toString();

--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -28,15 +28,21 @@ function RepositorySettings(options) {
     this._gitHubToken = options.gitHubToken;
     this._headers = {
         'User-Agent': 'cesium-concierge',
-        Authorization: 'token ' + options.gitHubToken
+        Authorization: 'token ' + this.gitHubToken
     };
 
     this.thirdPartyFolders = defaultValue(options.thirdPartyFolders, []);
-    this.signature = defaultValue(options.signature, defaultSignature);
+
     this.issueClosedTemplate = defaultValue(options.issueClosedTemplate, defaultIssueClosed);
     this.pullRequestOpenedTemplate = defaultValue(options.pullRequestOpenedTemplate, defaultPullRequestOpened);
     this.initialStalePullRequestTemplate = defaultValue(options.initialStalePullRequestTemplate, defaultInitialStalePullRequest);
     this.secondaryStalePullRequestTemplate = defaultValue(options.secondaryStalePullRequestTemplate, defaultSecondaryStalePullRequest);
+
+    /**
+     * Gets the raw template for the signature at the bottom of each comment template.
+     * @type {String}
+     */
+    this.signature = defaultValue(options.signature, defaultSignature);
 
     /**
      * Gets the URL of the CLA to use for this repository.
@@ -47,6 +53,9 @@ function RepositorySettings(options) {
      * Gets the amount of days before a pull request is considered stale.
      */
     this.maxDaysSinceUpdate = defaultValue(options.maxDaysSinceUpdate, defaultMaxDaysSinceUpdate);
+
+    // Exposed for testing
+    this._loadRepoConfig = loadRepoConfig;
 }
 
 Object.defineProperties(RepositorySettings.prototype, {
@@ -108,19 +117,6 @@ Object.defineProperties(RepositorySettings.prototype, {
     },
 
     /**
-     * Gets the raw template for the signature at the bottom of each comment template.
-     * @type {String}
-     */
-    signature: {
-        get: function () {
-            return '\n\n' + this._signature;
-        },
-        set: function (value) {
-            this._signature = value;
-        }
-    },
-
-    /**
      * Gets the handlebars template to use when commenting on a closed issue.
      * @type {String}
      */
@@ -178,7 +174,7 @@ Object.defineProperties(RepositorySettings.prototype, {
  * @returns {Promise<Object|String>} A Promise that resolves with the new configuration, or the error message if the Promise fails.
  */
 RepositorySettings.prototype.fetchSettings = function () {
-    return loadRepoConfig(this.name, this.headers, this);
+    return this._loadRepoConfig(this.name, this.headers, this);
 };
 
 module.exports = RepositorySettings;

--- a/lib/Settings.js
+++ b/lib/Settings.js
@@ -4,6 +4,7 @@ var Cesium = require('cesium');
 var nconf = require('nconf');
 var Promise = require('bluebird');
 
+var loadRepoConfig = require('./loadRepoConfig');
 var RepositorySettings = require('./RepositorySettings');
 
 var defined = Cesium.defined;
@@ -28,7 +29,6 @@ Settings.loadRepositoriesSettings = function (configPath) {
         });
 
     var repositoryNames;
-    var name;
     var configJson;
 
     if (!defined(nconf.get('secret'))) {
@@ -42,19 +42,23 @@ Settings.loadRepositoriesSettings = function (configPath) {
     if (repositoryNames.length === 0) {
         return Promise.reject('`repositories` must be non-empty');
     }
-    for (var i = 0; i < repositoryNames.length; i++) {
-        name = repositoryNames[i];
+    return Promise.each(repositoryNames, function (name) {
         if (!/\//.test(name)) {
             return Promise.reject('repository ' + name + ' must be in the form {user}/{repository}');
         }
+
         var repositorySettings = configJson[name];
         if (!defined(repositorySettings.gitHubToken)) {
             return Promise.reject('repository ' + name + ' must have a `gitHubToken`');
         }
 
-        repositories[name] = new RepositorySettings(repositorySettings);
-    }
-    return Promise.resolve();
+        return loadRepoConfig(name, {
+            'User-Agent': 'cesium-concierge',
+            Authorization: 'token ' + repositorySettings.gitHubToken
+        }, repositorySettings).then(function (settings) {
+            repositories[name] = new RepositorySettings(settings);
+        });
+    });
 };
 
 Object.defineProperties(Settings, {

--- a/lib/Settings.js
+++ b/lib/Settings.js
@@ -52,6 +52,8 @@ Settings.loadRepositoriesSettings = function (configPath) {
             return Promise.reject('repository ' + name + ' must have a `gitHubToken`');
         }
 
+        repositorySettings.name = name;
+
         return loadRepoConfig(name, {
             'User-Agent': 'cesium-concierge',
             Authorization: 'token ' + repositorySettings.gitHubToken

--- a/lib/commentOnClosedIssue.js
+++ b/lib/commentOnClosedIssue.js
@@ -45,11 +45,14 @@ commentOnClosedIssue._implementation = function (issueUrl, commentsUrl, reposito
     var comments = [];
     var issueHtmlUrl;
 
-    return requestPromise.get({
-        url: issueUrl,
-        headers: repositorySettings.headers,
-        json: true
-    })
+    return repositorySettings.fetchSettings()
+        .then(function () {
+            return requestPromise.get({
+                url: issueUrl,
+                headers: repositorySettings.headers,
+                json: true
+            });
+        })
         .then(function (issueResponse) {
             issueHtmlUrl = issueResponse.html_url;
             comments.push(issueResponse.body);

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -33,7 +33,10 @@ function commentOnOpenedPullRequest(body, repositorySettings) {
 commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, userName, repositoryUrl) {
     var claEnabled = defined(repositorySettings.claUrl);
     var askForCla = false;
-    return commentOnOpenedPullRequest._askForCla(userName, repositorySettings)
+    return repositorySettings.fetchSettings()
+        .then(function () {
+            return commentOnOpenedPullRequest._askForCla(userName, repositorySettings);
+        })
         .then(function (result) {
             askForCla = result;
         })

--- a/lib/loadRepoConfig.js
+++ b/lib/loadRepoConfig.js
@@ -30,7 +30,7 @@ function loadRepoConfig(repositoryName, headers, config) {
         });
 }
 
-loadRepoConfig._configDirectory = '.bot';
+loadRepoConfig._configDirectory = '.concierge';
 loadRepoConfig._configFile = 'config.json';
 loadRepoConfig._templateDirectory = 'templates';
 

--- a/lib/loadRepoConfig.js
+++ b/lib/loadRepoConfig.js
@@ -36,11 +36,11 @@ loadRepoConfig._templateDirectory = 'templates';
 
 loadRepoConfig._getConfig = function (configUrl, headers, config) {
     return requestPromise.get({
-        url: path.join(configUrl, loadRepoConfig._configFile),
-        headers: headers,
-        json: true
-    })
-        .then (function (response) {
+            url: path.join(configUrl, loadRepoConfig._configFile),
+            headers: headers,
+            json: true
+        })
+        .then(function (response) {
             var repoConfig = JSON.parse(response.content);
 
             for (var key in repoConfig) {
@@ -51,45 +51,45 @@ loadRepoConfig._getConfig = function (configUrl, headers, config) {
 
             return config;
         })
-        .catch (function (error) {
+        .catch(function (error) {
             return catchNotFound(error, config);
         });
 };
 
 loadRepoConfig._getTemplates = function (configUrl, headers, config) {
     return requestPromise.get({
-        url: path.join(configUrl, loadRepoConfig._templateDirectory),
-        headers: headers,
-        json: true
-    })
-        .then (function (response) {
+            url: path.join(configUrl, loadRepoConfig._templateDirectory),
+            headers: headers,
+            json: true
+        })
+        .then(function (response) {
             return Promise.each(response, function (template) {
                 if (path.extname(template.name) === '.hbs') {
                     var property = path.basename(template.name, '.hbs') + 'Template';
-                    config[property] = loadRepoConfig._getTemplate(template.url , headers);
+                    config[property] = loadRepoConfig._getTemplate(template.url, headers);
                 }
             }).then(function () {
                 return config;
             });
         })
-        .catch (function (error) {
+        .catch(function (error) {
             return catchNotFound(error, config);
         });
 };
 
 loadRepoConfig._getTemplate = function (url, headers) {
     return requestPromise.get({
-        url: url,
-        headers: headers,
-        json: true
-    })
-        .then (function(response) {
+            url: url,
+            headers: headers,
+            json: true
+        })
+        .then(function (response) {
             return response.content;
         });
 };
 
-function catchNotFound (error, config) {
-    if (error.message === 'Not Found') {
+function catchNotFound(error, config) {
+    if (error.statusCode === 404) {
         // No config file present, return default configuration
         return config;
     }

--- a/lib/loadRepoConfig.js
+++ b/lib/loadRepoConfig.js
@@ -1,0 +1,98 @@
+'use strict';
+var path = require('path');
+
+var Cesium = require('cesium');
+var Promise = require('bluebird');
+var requestPromise = require('request-promise');
+
+var Check = Cesium.Check;
+
+module.exports = loadRepoConfig;
+
+/**
+ * Loads any additional repository settings configuration or templates from the specified repository.
+ *
+ * @param {String} repositoryName The GitHub repository full name.
+ * @param {Object} headers The headers to supply to the request.
+ * @param {Object} config The default configuration settings to fall back on.
+ * @returns {Promise<Object|String>} A Promise that resolves with the new configuration, or the error message if the Promise fails.
+ */
+function loadRepoConfig(repositoryName, headers, config) {
+    Check.typeOf.string('repositoryName', repositoryName);
+    Check.typeOf.object('headers', headers);
+    Check.typeOf.object('config', config);
+
+    var configUrl = path.join('https://api.github.com/repos', repositoryName, 'contents', loadRepoConfig._configDirectory);
+
+    return loadRepoConfig._getConfig(configUrl, headers, config)
+        .then(function () {
+            return loadRepoConfig._getTemplates(configUrl, headers, config);
+        });
+}
+
+loadRepoConfig._configDirectory = '.bot';
+loadRepoConfig._configFile = 'config.json';
+loadRepoConfig._templateDirectory = 'templates';
+
+loadRepoConfig._getConfig = function (configUrl, headers, config) {
+    return requestPromise.get({
+        url: path.join(configUrl, loadRepoConfig._configFile),
+        headers: headers,
+        json: true
+    })
+        .then (function (response) {
+            var repoConfig = JSON.parse(response.content);
+
+            for (var key in repoConfig) {
+                if (repoConfig.hasOwnProperty(key)) {
+                    config[key] = repoConfig[key];
+                }
+            }
+
+            return config;
+        })
+        .catch (function (error) {
+            return catchNotFound(error, config);
+        });
+};
+
+loadRepoConfig._getTemplates = function (configUrl, headers, config) {
+    return requestPromise.get({
+        url: path.join(configUrl, loadRepoConfig._templateDirectory),
+        headers: headers,
+        json: true
+    })
+        .then (function (response) {
+            return Promise.each(response, function (template) {
+                if (path.extname(template.name) === '.hbs') {
+                    var property = path.basename(template.name, '.hbs') + 'Template';
+                    config[property] = loadRepoConfig._getTemplate(template.url , headers);
+                }
+            }).then(function () {
+                return config;
+            });
+        })
+        .catch (function (error) {
+            return catchNotFound(error, config);
+        });
+};
+
+loadRepoConfig._getTemplate = function (url, headers) {
+    return requestPromise.get({
+        url: url,
+        headers: headers,
+        json: true
+    })
+        .then (function(response) {
+            return response.content;
+        });
+};
+
+function catchNotFound (error, config) {
+    if (error.message === 'Not Found') {
+        // No config file present, return default configuration
+        return config;
+    }
+
+    return Promise.reject(error);
+}

--- a/lib/templates/signature.hbs
+++ b/lib/templates/signature.hbs
@@ -1,1 +1,3 @@
+---
+
 __I am a bot who helps you make Cesium awesome!__ Thanks again.

--- a/specs/lib/RepositorySettingsSpec.js
+++ b/specs/lib/RepositorySettingsSpec.js
@@ -1,0 +1,23 @@
+'use strict';
+var Promise = require('bluebird');
+
+var RepositorySettings = require('../../lib/RepositorySettings');
+
+describe('RepositorySettings', function () {
+    it('fetchSettings requests repository settings from repo', function (done) {
+        var settings = new RepositorySettings({
+            name: 'Org/repo'
+        });
+
+        spyOn(settings, '_loadRepoConfig').and.callFake(function () {
+            return Promise.resolve(settings);
+        });
+
+        settings.fetchSettings()
+            .then(function () {
+                expect(settings._loadRepoConfig).toHaveBeenCalledWith(settings.name, settings.headers, settings);
+                done();
+            })
+            .catch(done.fail);
+    });
+});

--- a/specs/lib/commentOnClosedIssueSpec.js
+++ b/specs/lib/commentOnClosedIssueSpec.js
@@ -73,6 +73,10 @@ describe('commentOnClosedIssue', function () {
             body: forumLinks[1]
         }];
 
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+           return Promise.resolve(repositorySettings);
+        });
+
         spyOn(requestPromise, 'get').and.callFake(function (options) {
             if (options.url === issueUrl) {
                 return Promise.resolve(issueResponseJson);
@@ -87,6 +91,19 @@ describe('commentOnClosedIssue', function () {
 
         return commentOnClosedIssue._implementation('issueUrl', 'commentsUrl', repositorySettings);
     }
+
+    it('commentOnClosedIssue._implementation fetches latest repository settings.', function (done) {
+        var forumLinks = [
+            '',
+            ''
+        ];
+        runTestWithLinks(forumLinks)
+            .then(function () {
+                expect(repositorySettings.fetchSettings).toHaveBeenCalled();
+                done();
+            })
+            .catch(done.fail);
+    });
 
     it('commentOnClosedIssue._implementation posts expected message.', function (done) {
         var forumLinks = [
@@ -125,9 +142,12 @@ describe('commentOnClosedIssue', function () {
             .catch(done.fail);
     });
 
-    it('commentOnClosedIssue._implementation rejects is issueUrl cannot be retrieved.', function (done) {
+    it('commentOnClosedIssue._implementation rejects if issueUrl cannot be retrieved.', function (done) {
         var commentsJson = [];
 
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
+        });
         spyOn(requestPromise, 'get').and.callFake(function (options) {
             if (options.url === issueUrl) {
                 return Promise.reject('Bad request');
@@ -140,7 +160,7 @@ describe('commentOnClosedIssue', function () {
         });
         spyOn(requestPromise, 'post');
 
-        commentOnClosedIssue._implementation('issueUrl', 'commentsUrl', repositorySettings.headers)
+        commentOnClosedIssue._implementation('issueUrl', 'commentsUrl', repositorySettings)
             .then(done.fail)
             .catch(function (error) {
                 expect(error).toEqual('Bad request');
@@ -149,12 +169,15 @@ describe('commentOnClosedIssue', function () {
             });
     });
 
-    it('commentOnClosedIssue._implementation rejects is commentsUrl cannot be retrieved.', function (done) {
+    it('commentOnClosedIssue._implementation rejects if commentsUrl cannot be retrieved.', function (done) {
         var issueResponseJson = {
             html_url: 'html_url',
             body: ''
         };
 
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
+        });
         spyOn(requestPromise, 'get').and.callFake(function (options) {
             if (options.url === issueUrl) {
                 return Promise.resolve(issueResponseJson);
@@ -168,7 +191,7 @@ describe('commentOnClosedIssue', function () {
         });
         spyOn(requestPromise, 'post');
 
-        commentOnClosedIssue._implementation('issueUrl', 'commentsUrl', repositorySettings.headers)
+        commentOnClosedIssue._implementation('issueUrl', 'commentsUrl', repositorySettings)
             .then(done.fail)
             .catch(function (error) {
                 expect(error).toEqual('Bad request');

--- a/specs/lib/commentOnOpenedPullRequestSpec.js
+++ b/specs/lib/commentOnOpenedPullRequestSpec.js
@@ -76,11 +76,44 @@ describe('commentOnOpenedPullRequest', function () {
         expect(commentOnOpenedPullRequest._askAboutThirdParty(['NotThirdParty/file.js'], ['ThirdParty'])).toBe(false);
     });
 
+    it('commentOnOpenedPullRequest._implementation fetches latest repository settings.', function (done) {
+        var pullRequestFilesUrl = 'pullRequestFilesUrl';
+        var pullRequestCommentsUrl = 'pullRequestCommentsUrl';
+
+        var repositorySettings = new RepositorySettings();
+
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
+        });
+
+        spyOn(requestPromise, 'post');
+
+        spyOn(requestPromise, 'get').and.callFake(function (options) {
+            if (options.url === pullRequestFilesUrl) {
+                return Promise.resolve([
+                    {filename: 'CHANGES.md'}
+                ]);
+            }
+            return Promise.reject('Unknown url.');
+        });
+
+        commentOnOpenedPullRequest._implementation(pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, userName, repositoryUrl)
+            .then(function () {
+                expect(repositorySettings.fetchSettings).toHaveBeenCalled();
+                done();
+            })
+            .catch(done.fail);
+    });
+
     it('commentOnOpenedPullRequest._implementation posts CLA confirmation if CHANGES.md was updated and there are no modified ThirdParty folders or CLA', function (done) {
         var pullRequestFilesUrl = 'pullRequestFilesUrl';
         var pullRequestCommentsUrl = 'pullRequestCommentsUrl';
 
         var repositorySettings = new RepositorySettings();
+
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
+        });
 
         spyOn(requestPromise, 'post');
 
@@ -121,6 +154,10 @@ describe('commentOnOpenedPullRequest', function () {
 
         var repositorySettings = new RepositorySettings({
             thirdPartyFolders: thirdPartyFolders.join(',')
+        });
+
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
         });
 
         spyOn(requestPromise, 'post');
@@ -164,6 +201,10 @@ describe('commentOnOpenedPullRequest', function () {
             thirdPartyFolders: thirdPartyFolders.join(',')
         });
 
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
+        });
+
         spyOn(requestPromise, 'post');
 
         spyOn(requestPromise, 'get').and.callFake(function (options) {
@@ -205,6 +246,11 @@ describe('commentOnOpenedPullRequest', function () {
         var repositorySettings = new RepositorySettings({
             thirdPartyFolders: thirdPartyFolders.join(',')
         });
+
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
+        });
+
         spyOn(requestPromise, 'post');
 
         spyOn(requestPromise, 'get').and.callFake(function (options) {
@@ -246,6 +292,10 @@ describe('commentOnOpenedPullRequest', function () {
         var repositorySettings = new RepositorySettings({
             thirdPartyFolders: thirdPartyFolders.join(','),
             claUrl: claUrl
+        });
+
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
         });
 
         spyOn(requestPromise, 'post');
@@ -293,12 +343,16 @@ describe('commentOnOpenedPullRequest', function () {
         var pullRequestCommentsUrl = 'pullRequestCommentsUrl';
         var claUrl = 'cla.json';
 
-        spyOn(requestPromise, 'post');
-
         var repositorySettings = new RepositorySettings({
             thirdPartyFolders: thirdPartyFolders.join(','),
             claUrl: claUrl
         });
+
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
+        });
+
+        spyOn(requestPromise, 'post');
 
         spyOn(requestPromise, 'get').and.callFake(function (options) {
             if (options.url === pullRequestFilesUrl) {

--- a/specs/lib/loadRepoConfigSpec.js
+++ b/specs/lib/loadRepoConfigSpec.js
@@ -14,7 +14,11 @@ describe('loadRepoConfig', function () {
     };
 
     var notFoundResponse = {
-        message: 'Not Found'
+        statusCode: 404
+    };
+
+    var unexpectedErrorRespomse = {
+        statusCode: 201
     };
 
     var configFileUrl = path.join(configUrl, loadRepoConfig._configFile);
@@ -107,6 +111,18 @@ describe('loadRepoConfig', function () {
                 })
                 .catch(done.fail);
         });
+
+        it ('rejects on unexpected error', function (done) {
+            spyOn(requestPromise, 'get').and.callFake(function () {
+                return Promise.reject(unexpectedErrorRespomse);
+            });
+
+            loadRepoConfig._getConfig(configUrl, {}, initialConfig)
+                .then(function () {
+                    done.fail();
+                })
+                .catch(done);
+        });
     });
 
     describe('_getTemplates', function () {
@@ -160,6 +176,18 @@ describe('loadRepoConfig', function () {
                     done();
                 })
                 .catch(done.fail);
+        });
+
+        it ('rejects on unexpected error', function (done) {
+            spyOn(requestPromise, 'get').and.callFake(function () {
+                return Promise.reject(unexpectedErrorRespomse);
+            });
+
+            loadRepoConfig._getTemplates(configUrl, {}, initialConfig)
+                .then(function () {
+                    done.fail();
+                })
+                .catch(done);
         });
     });
 

--- a/specs/lib/loadRepoConfigSpec.js
+++ b/specs/lib/loadRepoConfigSpec.js
@@ -1,0 +1,182 @@
+'use strict';
+var path = require('path');
+
+var Promise = require('bluebird');
+var requestPromise = require('request-promise');
+
+var loadRepoConfig = require('../../lib/loadRepoConfig');
+
+describe('loadRepoConfig', function () {
+    var configUrl = '//config.url/';
+    var initialConfig = {
+        option: 1,
+        option2: 2
+    };
+
+    var notFoundResponse = {
+        message: 'Not Found'
+    };
+
+    var configFileUrl = path.join(configUrl, loadRepoConfig._configFile);
+    var sampleConfig = {
+        option: 'myValue',
+        optionList: [1, 2, 3]
+    };
+    var configFileResponseJson = {
+        name: loadRepoConfig.configFile,
+        content: JSON.stringify(sampleConfig)
+    };
+
+    var templatesUrl = path.join(configUrl, loadRepoConfig._templateDirectory);
+    var templatesResponseJson = [{
+        name: 'signature.hbs',
+        url: '//file.url'
+    }, {
+        name: 'issueClosed.hbs',
+        url: '//file.url'
+    }, {
+        name: 'another.json',
+        url: '//file.url'
+    }];
+
+    var templateUrl = '//template.url';
+    var templateFileResponseJson = {
+        name: 'signature.hbs',
+        content: 'Here is a template'
+    };
+
+    it('populates configuration option based on supplied config file and template directory', function (done) {
+        spyOn(loadRepoConfig, '_getConfig').and.callFake(function () {
+            return Promise.resolve({});
+        });
+        spyOn(loadRepoConfig, '_getTemplates').and.callFake(function () {
+            return Promise.resolve({});
+        });
+
+        loadRepoConfig('Org/repo-name', {}, {}).then(function () {
+            var expectedUrl = path.join('https://api.github.com/repos/Org/repo-name/contents', loadRepoConfig._configDirectory);
+
+            expect(loadRepoConfig._getConfig).toHaveBeenCalledWith(expectedUrl, {}, {});
+            expect(loadRepoConfig._getTemplates).toHaveBeenCalledWith(expectedUrl, {}, {});
+
+            done();
+        });
+    });
+
+    describe('_getConfig', function () {
+        it('requests the expected url', function (done) {
+            spyOn(requestPromise, 'get').and.callFake(function (options) {
+                if (options.url === configFileUrl) {
+                    return Promise.resolve(configFileResponseJson);
+                }
+
+                return Promise.reject();
+            });
+
+            loadRepoConfig._getConfig(configUrl, {}, initialConfig)
+                .then(done)
+                .catch(done.fail);
+        });
+
+        it('sets configuration for each property in config file', function (done) {
+            var sampleHeaders = {};
+
+            spyOn(requestPromise, 'get').and.callFake(function () {
+                return Promise.resolve(configFileResponseJson);
+            });
+
+            loadRepoConfig._getConfig(configUrl, sampleHeaders, initialConfig)
+                .then(function (config) {
+                    expect(config.option).toEqual(sampleConfig.option);
+                    expect(config.option2).toEqual(initialConfig.option2);
+                    expect(config.optionList).toEqual(sampleConfig.optionList);
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it ('returns default configuration if there is no template directory', function (done) {
+            spyOn(requestPromise, 'get').and.callFake(function () {
+                return Promise.reject(notFoundResponse);
+            });
+
+            loadRepoConfig._getConfig(configUrl, {}, initialConfig)
+                .then(function (config) {
+                    expect(config).toEqual(initialConfig);
+                    done();
+                })
+                .catch(done.fail);
+        });
+    });
+
+    describe('_getTemplates', function () {
+        it('requests the expected url', function (done) {
+            spyOn(requestPromise, 'get').and.callFake(function (options) {
+                if (options.url === templatesUrl) {
+                    return Promise.resolve(templatesResponseJson);
+                }
+
+                return Promise.reject();
+            });
+
+            loadRepoConfig._getTemplates(configUrl, {}, initialConfig)
+                .then(done)
+                .catch(done.fail);
+        });
+
+        it('sets template content for each .hbr file', function (done) {
+            var sampleHeaders = {};
+
+            spyOn(requestPromise, 'get').and.callFake(function () {
+                return Promise.resolve(templatesResponseJson);
+            });
+
+            spyOn(loadRepoConfig, '_getTemplate').and.callFake(function (url, headers) {
+                expect(url).toBeDefined();
+                expect(headers).toBe(sampleHeaders);
+                return 'A template';
+            });
+
+            loadRepoConfig._getTemplates(configUrl, sampleHeaders, initialConfig)
+                .then(function (config) {
+                    expect(config.option).toEqual(initialConfig.option);
+                    expect(config.option2).toEqual(initialConfig.option2);
+                    expect(config.signatureTemplate).toEqual('A template');
+                    expect(config.issueClosedTemplate).toEqual('A template');
+                    expect(config.anotherTemplate).toBeUndefined();
+                    done();
+                })
+                .catch(done.fail);
+        });
+
+        it ('returns default configuration if there is no template directory', function (done) {
+            spyOn(requestPromise, 'get').and.callFake(function () {
+                return Promise.reject(notFoundResponse);
+            });
+
+            loadRepoConfig._getTemplates(configUrl, {}, initialConfig)
+                .then(function (config) {
+                    expect(config).toEqual(initialConfig);
+                    done();
+                })
+                .catch(done.fail);
+        });
+    });
+
+    it('_getTemplate requests and returns the content of a template file', function (done) {
+        spyOn(requestPromise, 'get').and.callFake(function (options) {
+            if (options.url === templateUrl) {
+                return Promise.resolve(templateFileResponseJson);
+            }
+
+            return Promise.reject();
+        });
+
+        loadRepoConfig._getTemplate(templateUrl, {})
+            .then(function (content) {
+                expect(content).toEqual(templateFileResponseJson.content);
+                done();
+            })
+            .catch(done.fail);
+    });
+});


### PR DESCRIPTION
Fixes #73

Allow repository settings and templates to be loaded from files stores in the github repo. These settings will override the environment variables and default config files.

Configuration file naming and structure that it will look for:
```
.concierge/
  templates/
    signature.hbs
    ...
  config.json
```