### PR TITLE
Template fixes

### DIFF
--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -13,7 +13,7 @@ var defaultInitialStalePullRequest = fs.readFileSync(path.join(__dirname, 'templ
 var defaultIssueClosed = fs.readFileSync(path.join(__dirname, 'templates', 'issueClosed.hbs')).toString();
 var defaultPullRequestOpened = fs.readFileSync(path.join(__dirname, 'templates', 'pullRequestOpened.hbs')).toString();
 var defaultSecondaryStalePullRequest = fs.readFileSync(path.join(__dirname, 'templates', 'secondaryStalePullRequest.hbs')).toString();
-var defaultSignature = fs.readFileSync(path.join(__dirname, 'templates', 'signature.hbs')).toString();
+var defaultSignatureTemplate = fs.readFileSync(path.join(__dirname, 'templates', 'signature.hbs')).toString();
 var defaultMaxDaysSinceUpdate = 30;
 
 /**
@@ -42,7 +42,7 @@ function RepositorySettings(options) {
      * Gets the raw template for the signature at the bottom of each comment template.
      * @type {String}
      */
-    this.signature = defaultValue(options.signature, defaultSignature);
+    this.signatureTemplate = defaultValue(options.signatureTemplate, defaultSignatureTemplate);
 
     /**
      * Gets the URL of the CLA to use for this repository.
@@ -122,7 +122,7 @@ Object.defineProperties(RepositorySettings.prototype, {
      */
     issueClosedTemplate: {
         get: function () {
-            return handlebars.compile(this._issueClosedTemplate + this.signature);
+            return handlebars.compile(this._issueClosedTemplate + this.signatureTemplate);
         },
         set: function (value) {
             this._issueClosedTemplate = value;
@@ -135,7 +135,7 @@ Object.defineProperties(RepositorySettings.prototype, {
      */
     pullRequestOpenedTemplate: {
         get: function () {
-            return handlebars.compile(this._pullRequestOpenedTemplate+ this.signature);
+            return handlebars.compile(this._pullRequestOpenedTemplate+ this.signatureTemplate);
         },
         set: function (value) {
             this._pullRequestOpenedTemplate = value;
@@ -148,7 +148,7 @@ Object.defineProperties(RepositorySettings.prototype, {
      */
     initialStalePullRequestTemplate: {
         get: function () {
-            return handlebars.compile(this._initialStalePullRequestTemplate + this.signature);
+            return handlebars.compile(this._initialStalePullRequestTemplate + this.signatureTemplate);
         },
         set: function (value) {
             this._initialStalePullRequestTemplate = value;
@@ -161,7 +161,7 @@ Object.defineProperties(RepositorySettings.prototype, {
      */
     secondaryStalePullRequestTemplate: {
         get: function () {
-            return handlebars.compile(this._secondaryStalePullRequestTemplate + this.signature);
+            return handlebars.compile(this._secondaryStalePullRequestTemplate + this.signatureTemplate);
         },
         set: function (value) {
             this._secondaryStalePullRequestTemplate = value;

--- a/lib/loadRepoConfig.js
+++ b/lib/loadRepoConfig.js
@@ -67,7 +67,9 @@ loadRepoConfig._getTemplates = function (configUrl, headers, config) {
             return Promise.each(response, function (template) {
                 if (path.extname(template.name) === '.hbs') {
                     var property = path.basename(template.name, '.hbs') + 'Template';
-                    config[property] = loadRepoConfig._getTemplate(template.url, headers);
+                    return loadRepoConfig._getTemplate(template.url, headers).then(function (content) {
+                        config[property] = content;
+                    });
                 }
             }).then(function () {
                 return config;
@@ -85,7 +87,8 @@ loadRepoConfig._getTemplate = function (url, headers) {
             json: true
         })
         .then(function (response) {
-            return response.content;
+            return Buffer.from(response.content, response.encoding)
+                .toString('ascii');
         });
 };
 

--- a/specs/lib/commentOnClosedIssueSpec.js
+++ b/specs/lib/commentOnClosedIssueSpec.js
@@ -118,8 +118,7 @@ describe('commentOnClosedIssue', function () {
                     body: {
                         body: repositorySettings.issueClosedTemplate({
                             html_url: 'html_url',
-                            forum_links: forumLinks,
-                            signature: repositorySettings.signature
+                            forum_links: forumLinks
                         })
                     },
                     json: true

--- a/specs/lib/loadRepoConfigSpec.js
+++ b/specs/lib/loadRepoConfigSpec.js
@@ -43,10 +43,12 @@ describe('loadRepoConfig', function () {
         url: '//file.url'
     }];
 
-    var templateUrl = '//template.url';
+    var templateUrl = 'https://config.url/templates/';
+    var templateContents = 'Here is a template.';
     var templateFileResponseJson = {
         name: 'signature.hbs',
-        content: 'Here is a template'
+        content: Buffer.from(templateContents, 'ascii').toString('base64'),
+        encoding: 'base64'
     };
 
     it('populates configuration option based on supplied config file and template directory', function (done) {
@@ -129,7 +131,7 @@ describe('loadRepoConfig', function () {
         it('requests the expected url', function (done) {
             spyOn(requestPromise, 'get').and.callFake(function (options) {
                 if (options.url === templatesUrl) {
-                    return Promise.resolve(templatesResponseJson);
+                    return Promise.resolve([]);
                 }
 
                 return Promise.reject();
@@ -150,7 +152,7 @@ describe('loadRepoConfig', function () {
             spyOn(loadRepoConfig, '_getTemplate').and.callFake(function (url, headers) {
                 expect(url).toBeDefined();
                 expect(headers).toBe(sampleHeaders);
-                return 'A template';
+                return Promise.resolve('A template');
             });
 
             loadRepoConfig._getTemplates(configUrl, sampleHeaders, initialConfig)
@@ -202,7 +204,7 @@ describe('loadRepoConfig', function () {
 
         loadRepoConfig._getTemplate(templateUrl, {})
             .then(function (content) {
-                expect(content).toEqual(templateFileResponseJson.content);
+                expect(content).toEqual(templateContents);
                 done();
             })
             .catch(done.fail);


### PR DESCRIPTION
Renamed `signature`->`signatureTemplate` so it can be loaded without special condition.

Also decode file contents from github so loaded templates are properly displayed.

@mramato 