### PR TITLE
Catch and log errors parsing CLA.json

### DIFF
--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -135,7 +135,7 @@ Object.defineProperties(RepositorySettings.prototype, {
      */
     pullRequestOpenedTemplate: {
         get: function () {
-            return handlebars.compile(this._pullRequestOpenedTemplate+ this.signatureTemplate);
+            return handlebars.compile(this._pullRequestOpenedTemplate + this.signatureTemplate);
         },
         set: function (value) {
             this._pullRequestOpenedTemplate = value;

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -33,6 +33,7 @@ function commentOnOpenedPullRequest(body, repositorySettings) {
 commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, userName, repositoryUrl) {
     var claEnabled = defined(repositorySettings.claUrl);
     var askForCla = false;
+    var errorCla;
     return repositorySettings.fetchSettings()
         .then(function () {
             return commentOnOpenedPullRequest._askForCla(userName, repositorySettings);
@@ -41,8 +42,7 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
             askForCla = result;
         })
         .catch(function(error) {
-            console.log('Error processing CLA.');
-            console.log(error);
+            errorCla = error.toString();
         })
         .then(function () {
             return requestPromise.get({
@@ -64,6 +64,7 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
                 repository_url: repositoryUrl,
                 claEnabled: claEnabled,
                 askForCla: askForCla,
+                errorCla: errorCla,
                 askAboutChanges: askAboutChanges,
                 askAboutThirdParty: askAboutThirdParty,
                 thirdPartyFolders: repositorySettings.thirdPartyFolders.join(', ')

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -40,6 +40,10 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
         .then(function (result) {
             askForCla = result;
         })
+        .catch(function(error) {
+            console.log('Error processing CLA.');
+            console.log(error);
+        })
         .then(function () {
             return requestPromise.get({
                 url: pullRequestFilesUrl,

--- a/lib/templates/pullRequestOpened.hbs
+++ b/lib/templates/pullRequestOpened.hbs
@@ -2,7 +2,7 @@
 {{#if errorCla}}
 @{{ userName }}, thanks for the pull request!
 
-If this is your first contribution, can you please send in a [Contributor License Agreement](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla) (CLA) so that we can review and merge this pull request?
+If this is your first contribution, please send in a [Contributor License Agreement](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla) (CLA) so that we can review and merge this pull request.
 
 Maintainers, there was an error processing the CLA, resolve it to continue CLA checking.
 ```

--- a/lib/templates/pullRequestOpened.hbs
+++ b/lib/templates/pullRequestOpened.hbs
@@ -1,10 +1,21 @@
 {{#if claEnabled}}
+{{#if errorCla}}
+@{{ userName }}, thanks for the pull request!
+
+If this is your first contribution, can you please send in a [Contributor License Agreement](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla) (CLA) so that we can review and merge this pull request?
+
+Maintainers, there was an error processing the CLA, resolve it to continue CLA checking.
+```
+{{ errorCla }}
+```
+{{else}}
 {{#if askForCla}}
 Welcome to the Cesium community @{{ userName }}!
 
 Can you please send in a [Contributor License Agreement](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla) (CLA) so that we can review and merge this pull request?
 {{else}}
 @{{ userName }}, thanks for the pull request! Maintainers, we have a signed CLA from @{{ userName }}, so you can review this at any time.
+{{/if}}
 {{/if}}
 {{else}}
 @{{ userName }}, thanks for the pull request!

--- a/specs/lib/commentOnOpenedPullRequestSpec.js
+++ b/specs/lib/commentOnOpenedPullRequestSpec.js
@@ -148,10 +148,11 @@ describe('commentOnOpenedPullRequest', function () {
             .catch(done.fail);
     });
 
-    it('commentOnOpenedPullRequest._implementation catches errors processing CLA.json', function (done) {
+    it('commentOnOpenedPullRequest._implementation catches and reports errors processing CLA.json', function (done) {
         var pullRequestFilesUrl = 'pullRequestFilesUrl';
         var pullRequestCommentsUrl = 'pullRequestCommentsUrl';
         var claUrl = 'cla.json';
+        var errorCla = new SyntaxError('Unexpected token a in JSON at position 15045');
 
         var repositorySettings = new RepositorySettings({
             claUrl: claUrl
@@ -171,7 +172,7 @@ describe('commentOnOpenedPullRequest', function () {
             }
 
             if (options.url === claUrl) {
-                return Promise.reject(new SyntaxError('Unexpected token a in JSON at position 15045'));
+                return Promise.reject(errorCla);
             }
             return Promise.reject('Unknown url.');
         });
@@ -187,6 +188,7 @@ describe('commentOnOpenedPullRequest', function () {
                             repository_url: repositoryUrl,
                             claEnabled: true,
                             askForCla: false,
+                            errorCla: errorCla.toString(),
                             askAboutChanges: false,
                             askAboutThirdParty: false,
                             thirdPartyFolders: thirdPartyFolders.join(', ')


### PR DESCRIPTION
The concierge should still post, and the error will be logged to stdout in the event the CLA request fails or does not parse.