### PR TITLE
Remind first time contributors to add name to CONTRIBUTORS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The possible settings are:
 | `repositories:{full_name}:gitHubToken` | `string` | Token used to verify __outgoing__ requests to GitHub repository | ✓
 | `repositories:{full_name}:thirdPartyFolders` | `string` | Comma-separated list of folders in which to look for changed files in pull request to remind user to update License. | X
 | `repositories:{full_name}:claUrl` | `string` | The GitHub API URL to the CLA file in JSON form. If undefined it disables CLA checking. See [here](https://developer.github.com/v3/repos/contents/#get-contents) for how the URL should look. _Example:_ https://api.github.com/repos/AnalyticalGraphicsInc/cesium-concierge/contents/specs/data/config/CLA.json | X
+| `repositories:{full_name}:contributorsUrl` | `string` | The GitHub API URL to the `CONTRIBUTORS.md` file in JSON form. If undefined it disables checking for first time contributors. | X
 | `repositories:{full_name}:maxDaysSinceUpdate` | `number` | "Bump" pull requests older than this number of days ago | X
 | `port` | `number: default 5000` | Port on which to listen to incoming requests | X
 | `listenPath` | `string: default"/"` | Path on which to listen for incoming requests | X

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The possible settings are:
 | `repositories:{full_name}:gitHubToken` | `string` | Token used to verify __outgoing__ requests to GitHub repository | ✓
 | `repositories:{full_name}:thirdPartyFolders` | `string` | Comma-separated list of folders in which to look for changed files in pull request to remind user to update License. | X
 | `repositories:{full_name}:claUrl` | `string` | The GitHub API URL to the CLA file in JSON form. If undefined it disables CLA checking. See [here](https://developer.github.com/v3/repos/contents/#get-contents) for how the URL should look. _Example:_ https://api.github.com/repos/AnalyticalGraphicsInc/cesium-concierge/contents/specs/data/config/CLA.json | X
-| `repositories:{full_name}:contributorsUrl` | `string` | The GitHub API URL to the `CONTRIBUTORS.md` file in JSON form. If `undefined`, checking for first time contributors will be disabled. | X
+| `repositories:{full_name}:contributorsUrl` | `string` | Url to `CONTRIBUTORS.md` relative to repository root. If `undefined`, checking for first time contributors will be disabled. | X
 | `repositories:{full_name}:maxDaysSinceUpdate` | `number` | "Bump" pull requests older than this number of days ago | X
 | `port` | `number: default 5000` | Port on which to listen to incoming requests | X
 | `listenPath` | `string: default"/"` | Path on which to listen for incoming requests | X

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The possible settings are:
 | `repositories:{full_name}:gitHubToken` | `string` | Token used to verify __outgoing__ requests to GitHub repository | ✓
 | `repositories:{full_name}:thirdPartyFolders` | `string` | Comma-separated list of folders in which to look for changed files in pull request to remind user to update License. | X
 | `repositories:{full_name}:claUrl` | `string` | The GitHub API URL to the CLA file in JSON form. If undefined it disables CLA checking. See [here](https://developer.github.com/v3/repos/contents/#get-contents) for how the URL should look. _Example:_ https://api.github.com/repos/AnalyticalGraphicsInc/cesium-concierge/contents/specs/data/config/CLA.json | X
-| `repositories:{full_name}:contributorsUrl` | `string` | The GitHub API URL to the `CONTRIBUTORS.md` file in JSON form. If undefined it disables checking for first time contributors. | X
+| `repositories:{full_name}:contributorsUrl` | `string` | The GitHub API URL to the `CONTRIBUTORS.md` file in JSON form. If `undefined`, checking for first time contributors will be disabled. | X
 | `repositories:{full_name}:maxDaysSinceUpdate` | `number` | "Bump" pull requests older than this number of days ago | X
 | `port` | `number: default 5000` | Port on which to listen to incoming requests | X
 | `listenPath` | `string: default"/"` | Path on which to listen for incoming requests | X

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The possible settings are:
 | `repositories:{full_name}:gitHubToken` | `string` | Token used to verify __outgoing__ requests to GitHub repository | ✓
 | `repositories:{full_name}:thirdPartyFolders` | `string` | Comma-separated list of folders in which to look for changed files in pull request to remind user to update License. | X
 | `repositories:{full_name}:claUrl` | `string` | The GitHub API URL to the CLA file in JSON form. If undefined it disables CLA checking. See [here](https://developer.github.com/v3/repos/contents/#get-contents) for how the URL should look. _Example:_ https://api.github.com/repos/AnalyticalGraphicsInc/cesium-concierge/contents/specs/data/config/CLA.json | X
-| `repositories:{full_name}:contributorsUrl` | `string` | Url to `CONTRIBUTORS.md` relative to repository root. If `undefined`, checking for first time contributors will be disabled. | X
+| `repositories:{full_name}:contributorsUrl` | `string` | URL` to `CONTRIBUTORS.md` relative to repository root. If `undefined`, checking for first time contributors will be disabled. | X
 | `repositories:{full_name}:maxDaysSinceUpdate` | `number` | "Bump" pull requests older than this number of days ago | X
 | `port` | `number: default 5000` | Port on which to listen to incoming requests | X
 | `listenPath` | `string: default"/"` | Path on which to listen for incoming requests | X

--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -52,7 +52,7 @@ function RepositorySettings(options) {
     /**
      * Gets the URL of the CONTRIBUTORS markdown file for this repository.
      */
-    this.contributorsUrl = options.contributorsUrl;
+    this.contributorsUrl =  `https://api.github.com/repos/${options.name}/contents/` + options.contributorsUrl;
 
     /**
      * Gets the amount of days before a pull request is considered stale.

--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -50,6 +50,11 @@ function RepositorySettings(options) {
     this.claUrl = options.claUrl;
 
     /**
+     * Gets the URL of the CONTRIBUTORS markdown file for this repository.
+     */
+    this.contributorsUrl = options.contributorsUrl;
+
+    /**
      * Gets the amount of days before a pull request is considered stale.
      */
     this.maxDaysSinceUpdate = defaultValue(options.maxDaysSinceUpdate, defaultMaxDaysSinceUpdate);

--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -8,6 +8,7 @@ var path = require('path');
 var loadRepoConfig = require('./loadRepoConfig');
 
 var defaultValue = Cesium.defaultValue;
+var defined = Cesium.defined;
 
 var defaultInitialStalePullRequest = fs.readFileSync(path.join(__dirname, 'templates', 'initialStalePullRequest.hbs')).toString();
 var defaultIssueClosed = fs.readFileSync(path.join(__dirname, 'templates', 'issueClosed.hbs')).toString();
@@ -52,7 +53,7 @@ function RepositorySettings(options) {
     /**
      * Gets the URL of the CONTRIBUTORS markdown file for this repository.
      */
-    this.contributorsUrl =  'https://api.github.com/repos/' + options.name + '/contents/' + options.contributorsUrl;
+    this.contributorsUrl = defined(options.contributorsUrl) ? 'https://api.github.com/repos/' + options.name + '/contents/' + options.contributorsUrl : options.contributorsUrl;
 
     /**
      * Gets the amount of days before a pull request is considered stale.

--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -52,7 +52,7 @@ function RepositorySettings(options) {
     /**
      * Gets the URL of the CONTRIBUTORS markdown file for this repository.
      */
-    this.contributorsUrl =  `https://api.github.com/repos/${options.name}/contents/` + options.contributorsUrl;
+    this.contributorsUrl =  'https://api.github.com/repos/' + options.name + '/contents/' + options.contributorsUrl;
 
     /**
      * Gets the amount of days before a pull request is considered stale.

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -78,6 +78,7 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
                 askAboutThirdParty: askAboutThirdParty,
                 thirdPartyFolders: repositorySettings.thirdPartyFolders.join(', ')
             });
+
             return requestPromise.post({
                 url: pullRequestCommentsUrl,
                 headers: repositorySettings.headers,
@@ -105,7 +106,7 @@ commentOnOpenedPullRequest._askAboutContributors = function (userName, repositor
     if (!defined(repositorySettings.contributorsUrl)) {
         return Promise.resolve(false);
     }
-    
+
     return requestPromise.get({
         url: repositorySettings.contributorsUrl,
         headers: repositorySettings.headers,
@@ -118,14 +119,14 @@ commentOnOpenedPullRequest._askAboutContributors = function (userName, repositor
         var regex = /\[.+\]\(https:\/\/github.com\/(.*)\)/g;
         var match = regex.exec(contributorsFileContent);
         while (defined(match)) {
-            if (match[1] == userName) {
+            if (match[1] === userName) {
                 return false;
             }
             match = regex.exec(contributorsFileContent);
         }
-        return true; 
+        return true;
     });
-}
+};
 
 commentOnOpenedPullRequest._askAboutThirdParty = function (files, thirdPartyFolders) {
     if (!defined(thirdPartyFolders) || thirdPartyFolders.length === 0) {

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -34,6 +34,7 @@ function commentOnOpenedPullRequest(body, repositorySettings) {
 commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, userName, repositoryUrl, baseBranch) {
     var claEnabled = defined(repositorySettings.claUrl);
     var askForCla = false;
+    var askAboutContributors = false;
     var errorCla;
     return repositorySettings.fetchSettings()
         .then(function () {
@@ -44,6 +45,12 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
         })
         .catch(function(error) {
             errorCla = error.toString();
+        })
+        .then(function () {
+            return commentOnOpenedPullRequest._askAboutContributors(userName, repositorySettings);
+        })
+        .then(function (result) {
+            askAboutContributors = result;
         })
         .then(function () {
             return requestPromise.get({
@@ -67,6 +74,7 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
                 askForCla: askForCla,
                 errorCla: errorCla,
                 askAboutChanges: askAboutChanges,
+                askAboutContributors: askAboutContributors,
                 askAboutThirdParty: askAboutThirdParty,
                 thirdPartyFolders: repositorySettings.thirdPartyFolders.join(', ')
             });
@@ -92,6 +100,32 @@ commentOnOpenedPullRequest._askAboutChanges = function (files, baseBranch) {
     }
     return true;
 };
+
+commentOnOpenedPullRequest._askAboutContributors = function (userName, repositorySettings) {
+    if (!defined(repositorySettings.contributorsUrl)) {
+        return Promise.resolve(false);
+    }
+    
+    return requestPromise.get({
+        url: repositorySettings.contributorsUrl,
+        headers: repositorySettings.headers,
+        json: true
+    })
+    .then(function (response) {
+        var contributorsFileContent = Buffer.from(response.content, 'base64').toString();
+        // Matches items that look like: [<string>](https://github.com/<username>)
+        // sets the username as the first capturing group.
+        var regex = /\[.+\]\(https:\/\/github.com\/(.*)\)/g;
+        var match = regex.exec(contributorsFileContent);
+        while (defined(match)) {
+            if (match[1] == userName) {
+                return false;
+            }
+            match = regex.exec(contributorsFileContent);
+        }
+        return true; 
+    });
+}
 
 commentOnOpenedPullRequest._askAboutThirdParty = function (files, thirdPartyFolders) {
     if (!defined(thirdPartyFolders) || thirdPartyFolders.length === 0) {

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -114,8 +114,7 @@ commentOnOpenedPullRequest._askAboutContributors = function (userName, repositor
     })
     .then(function (response) {
         var contributorsFileContent = Buffer.from(response.content, 'base64').toString();
-        var regex = new RegExp('\\[.+\\]\\(https:\\/\\/github.com\\/' + userName + '\\)');
-        return !defined(contributorsFileContent.match(regex));
+        return contributorsFileContent.indexOf(userName) === -1;
     });
 };
 

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -114,17 +114,8 @@ commentOnOpenedPullRequest._askAboutContributors = function (userName, repositor
     })
     .then(function (response) {
         var contributorsFileContent = Buffer.from(response.content, 'base64').toString();
-        // Matches items that look like: [<string>](https://github.com/<username>)
-        // sets the username as the first capturing group.
-        var regex = /\[.+\]\(https:\/\/github.com\/(.*)\)/g;
-        var match = regex.exec(contributorsFileContent);
-        while (defined(match)) {
-            if (match[1] === userName) {
-                return false;
-            }
-            match = regex.exec(contributorsFileContent);
-        }
-        return true;
+        var regex = new RegExp('\\[.+\\]\\(https:\\/\\/github.com\\/' + userName + '\\)');
+        return !defined(contributorsFileContent.match(regex));
     });
 };
 

--- a/lib/templates/pullRequestOpened.hbs
+++ b/lib/templates/pullRequestOpened.hbs
@@ -21,6 +21,11 @@ Can you please send in a [Contributor License Agreement](https://github.com/Anal
 @{{ userName }}, thanks for the pull request!
 {{/if}}
 
+{{#if askAboutContributors}}
+Don't forget to add your name to the `CONTRIBUTORS.md` file!  
+
+{{/if}}
+
 {{#if askAboutChanges}}
 I noticed that [CHANGES.md]({{ repository_url }}/blob/master/CHANGES.md) has not been updated. If this change updates the public API in any way, fixes a bug, or makes any non-trivial update, please add a bullet point to `CHANGES.md` and comment on this pull request so we know it was updated. For more info, see the [Pull Request Guidelines]( https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#pull-request-guidelines).
 

--- a/lib/templates/pullRequestOpened.hbs
+++ b/lib/templates/pullRequestOpened.hbs
@@ -22,7 +22,7 @@ Can you please send in a [Contributor License Agreement](https://github.com/Anal
 {{/if}}
 
 {{#if askAboutContributors}}
-Don't forget to add your name to the `CONTRIBUTORS.md` file!  
+I noticed you haven't added yourself to `CONTRIBUTORS.md`. Please add yourself to that file and comment back here to let us know it's ready! 
 
 {{/if}}
 

--- a/specs/lib/commentOnOpenedPullRequestSpec.js
+++ b/specs/lib/commentOnOpenedPullRequestSpec.js
@@ -521,7 +521,7 @@ describe('commentOnOpenedPullRequest', function () {
                 ]);
             }
             if (options.url === contributorsUrl) {
-                var content = Buffer.from('* [Jane Doe](https://github.com/JaneDoe)\n* [Boomer Jones](https://github.com/'+userName+')').toString('base64');
+                var content = Buffer.from('* [Jane Doe](https://github.com/JaneDoe)\n* [Boomer Jones](https://github.com/' + userName + ')').toString('base64');
                 return Promise.resolve({
                     content: content
                 });
@@ -572,7 +572,7 @@ describe('commentOnOpenedPullRequest', function () {
                 ]);
             }
             if (options.url === contributorsUrl) {
-                var content = Buffer.from('* [Jane Doe](https://github.com/JaneDoe)\n* [Boomer Jones](https://github.com/'+userName+')').toString('base64');
+                var content = Buffer.from('* [Jane Doe](https://github.com/JaneDoe)\n* [Boomer Jones](https://github.com/' + userName + ')').toString('base64');
                 return Promise.resolve({
                     content: content
                 });

--- a/specs/lib/commentOnOpenedPullRequestSpec.js
+++ b/specs/lib/commentOnOpenedPullRequestSpec.js
@@ -498,4 +498,105 @@ describe('commentOnOpenedPullRequest', function () {
             })
             .catch(done.fail);
     });
+
+    it('commentOnOpenedPullRequest._implementation reminds user to add to CONTRIBUTORS.md.', function (done) {
+        var pullRequestFilesUrl = 'pullRequestFilesUrl';
+        var pullRequestCommentsUrl = 'pullRequestCommentsUrl';
+        var contributorsUrl = 'contributors.json';
+
+        var repositorySettings = new RepositorySettings({
+            contributorsUrl: contributorsUrl
+        });
+
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
+        });
+
+        spyOn(requestPromise, 'post');
+
+        spyOn(requestPromise, 'get').and.callFake(function (options) {
+            if (options.url === pullRequestFilesUrl) {
+                return Promise.resolve([
+                    {filename: 'file.txt'}
+                ]);
+            }
+            if (options.url === contributorsUrl) {
+                var content = Buffer.from('* [Jane Doe](https://github.com/JaneDoe)\n* [Boomer Jones](https://github.com/'+userName+')').toString('base64');
+                return Promise.resolve({
+                    content: content
+                });
+            }
+            return Promise.reject('Unknown url.');
+        });
+
+        var newContributorUsername = 'NewBob';
+        commentOnOpenedPullRequest._implementation(pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, newContributorUsername, repositoryUrl, baseBranch)
+            .then(function () {
+                expect(requestPromise.post).toHaveBeenCalledWith({
+                    url: pullRequestCommentsUrl,
+                    headers: repositorySettings.headers,
+                    body: {
+                        body: repositorySettings.pullRequestOpenedTemplate({
+                            userName: newContributorUsername,
+                            repository_url: repositoryUrl,
+                            askAboutContributors: true,
+                            askAboutChanges: true
+                        })
+                    },
+                    json: true
+                });
+                done();
+            })
+            .catch(done.fail);
+    });
+
+    it('commentOnOpenedPullRequest._implementation does not post reminder about CONTRIBUTORS.md if user is already in there.', function (done) {
+        var pullRequestFilesUrl = 'pullRequestFilesUrl';
+        var pullRequestCommentsUrl = 'pullRequestCommentsUrl';
+        var contributorsUrl = 'contributors.json';
+
+        var repositorySettings = new RepositorySettings({
+            contributorsUrl: contributorsUrl
+        });
+
+        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
+            return Promise.resolve(repositorySettings);
+        });
+
+        spyOn(requestPromise, 'post');
+
+        spyOn(requestPromise, 'get').and.callFake(function (options) {
+            if (options.url === pullRequestFilesUrl) {
+                return Promise.resolve([
+                    {filename: 'file.txt'}
+                ]);
+            }
+            if (options.url === contributorsUrl) {
+                var content = Buffer.from('* [Jane Doe](https://github.com/JaneDoe)\n* [Boomer Jones](https://github.com/'+userName+')').toString('base64');
+                return Promise.resolve({
+                    content: content
+                });
+            }
+            return Promise.reject('Unknown url.');
+        });
+
+        commentOnOpenedPullRequest._implementation(pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, userName, repositoryUrl, baseBranch)
+            .then(function () {
+                expect(requestPromise.post).toHaveBeenCalledWith({
+                    url: pullRequestCommentsUrl,
+                    headers: repositorySettings.headers,
+                    body: {
+                        body: repositorySettings.pullRequestOpenedTemplate({
+                            userName: userName,
+                            repository_url: repositoryUrl,
+                            askAboutContributors: false,
+                            askAboutChanges: true
+                        })
+                    },
+                    json: true
+                });
+                done();
+            })
+            .catch(done.fail);
+    });
 });

--- a/specs/lib/commentOnOpenedPullRequestSpec.js
+++ b/specs/lib/commentOnOpenedPullRequestSpec.js
@@ -520,7 +520,7 @@ describe('commentOnOpenedPullRequest', function () {
                     {filename: 'file.txt'}
                 ]);
             }
-            if (options.url === contributorsUrl) {
+            if (options.url === repositorySettings.contributorsUrl) {
                 var content = Buffer.from('* [Jane Doe](https://github.com/JaneDoe)\n* [Boomer Jones](https://github.com/' + userName + ')').toString('base64');
                 return Promise.resolve({
                     content: content
@@ -571,7 +571,7 @@ describe('commentOnOpenedPullRequest', function () {
                     {filename: 'file.txt'}
                 ]);
             }
-            if (options.url === contributorsUrl) {
+            if (options.url === repositorySettings.contributorsUrl) {
                 var content = Buffer.from('* [Jane Doe](https://github.com/JaneDoe)\n* [Boomer Jones](https://github.com/' + userName + ')').toString('base64');
                 return Promise.resolve({
                     content: content


### PR DESCRIPTION
Resolves https://github.com/AnalyticalGraphicsInc/cesium-concierge/issues/84

For this to work in the Cesium repository, we have to add to `contributorsUrl` to the Concierge settings in that repository. That url should be:

```
https://api.github.com/repos/AnalyticalGraphicsInc/cesium/contents/CONTRIBUTORS.md
```

This works by just checking the username of the account that opened the PR and parses `CONTRIBUTORS.md` to check all the usernames in there. A future PR can also abstract this method as a way to tell if this is a first time contributor to display other helpful messages, (as opposed to having to say "If this is your first PR do this" every time).

For tests, I added two separate tests to check the cases of when it should post a reminder vs when it should not. Let me know if those should be combined into one test or if this is good! I tested this on a personal private repository and it does correctly post and successfully detects a username in `CONTRIBUTORS.md`. 