### PR TITLE
Fixed parsing of repo settings

### DIFF
--- a/lib/loadRepoConfig.js
+++ b/lib/loadRepoConfig.js
@@ -42,7 +42,8 @@ loadRepoConfig._getConfig = function (configUrl, headers, config) {
             json: true
         })
         .then(function (response) {
-            var repoConfig = JSON.parse(response.content);
+            var content = Buffer.from(response.content, 'base64').toString();
+            var repoConfig = JSON.parse(content);
 
             for (var key in repoConfig) {
                 if (repoConfig.hasOwnProperty(key)) {

--- a/specs/lib/loadRepoConfigSpec.js
+++ b/specs/lib/loadRepoConfigSpec.js
@@ -28,7 +28,7 @@ describe('loadRepoConfig', function () {
     };
     var configFileResponseJson = {
         name: loadRepoConfig.configFile,
-        content: JSON.stringify(sampleConfig)
+        content: Buffer.from(JSON.stringify(sampleConfig)).toString('base64')
     };
 
     var templatesUrl = url.resolve(configUrl, loadRepoConfig._templateDirectory);


### PR DESCRIPTION
I'm not sure if this ever worked, but the content returned from `requestPromise.get` returns a base64 encoded string, so trying to parse it as a JSON was failing when a repo had configuration settings in `.concierge/config.json`. 