### PR TITLE
Update node and set shell to bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:10
 
 ENV NODE_ENV production
 
@@ -12,5 +12,7 @@ COPY . /var/app
 WORKDIR /var/app
 
 RUN npm install
+
+RUN npm config set script-shell /bin/bash
 
 ENTRYPOINT ["/usr/bin/supervisord", "-c", "/var/app/supervisord.conf"]


### PR DESCRIPTION
Concierge is currently broken because it's running with `/bin/sh` which doesn't like our environment variables (which are not valid because they have characters like `-` and `/` in them). The solution is to use `/bin/bash` and that requires at least `npm 5` so it's a good reason to update.

I tested this locally and all tests run. I couldn't actually confirm this solves the problem locally because I can't set environment variables like that on the command line (because they're invalid). I'm not sure what magic AWS does behind the scenes to force these environment variables in. 

I know this works because I ssh'ed into the running instance and ran a test script that showed it is correctly printing out the environment variables when running with `/bin/bash`. @mramato this should be a quick merge since we've already discussed offline. 

See here for more context on the issue https://npm.community/t/missing-environment-variables-when-npm-start/3980