### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Cesium Concierge
 
 __Hello! I'm Cesium Concierge, a GitHub bot for [Cesium](https://github.com/AnalyticalGraphicsInc/cesium). I automate
-common GitHub tasks such as welcoming first time contributors and reminding you to write tests (I'm great fun at parties).__
+common GitHub tasks such as welcoming first time contributors and reminding you to write tests. (I'm great fun at parties!)__
 
-You'll find repository-specific settings for each repository I watch under a `.concierge` directory. For example, here's CesiumJS's concierge settings:
+You'll find repository-specific settings in each repository I watch under a `.concierge` directory. For example, here's CesiumJS's concierge settings:
 
 https://github.com/AnalyticalGraphicsInc/cesium/tree/master/.concierge 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-# cesium-concierge
+# Cesium Concierge
 
-__Hello! I'm Cesium Conierge, a GitHub bot for [Cesium](https://github.com/AnalyticalGraphicsInc/cesium). I automate
-common certain GitHub tasks, and can currently:__
-- Post a reminder comment to closed issues that have Google Group links in them
-- Post a suggestion to update `CHANGES.md` on newly-opened pull requests, and/or to update licenses if files in Third-party folders have changed.
+__Hello! I'm Cesium Concierge, a GitHub bot for [Cesium](https://github.com/AnalyticalGraphicsInc/cesium). I automate
+common GitHub tasks such as welcoming first time contributors and reminding you to write tests (I'm great fun at parties).__
+
+You'll find repository-specific settings for each repository I watch under a `.concierge` directory. For example, here's CesiumJS's concierge settings:
+
+https://github.com/AnalyticalGraphicsInc/cesium/tree/master/.concierge 
+
 ## Building
 
 Clone this repository:
@@ -72,5 +75,5 @@ The `gitHub` value is the only required field, but this format provides for stor
 ---
 
 <p align="center">
-  <a href="http://cesiumjs.org/"><img width="250px" src="https://cesiumjs.org/images/logos/cesium-black.png" /></a>
+  <a href="http://cesium.com/"><img width="250px" src="https://raw.githubusercontent.com/wiki/AnalyticalGraphicsInc/cesium/logos/Cesium_Logo_Color.jpg" /></a>
 </p>


### PR DESCRIPTION
This fixes a bunch of typos, including a broken link to the Cesium logo. 