### PR TITLE
Make stale PR bumper check for recent commits

### DIFF
--- a/lib/stalePullRequest.js
+++ b/lib/stalePullRequest.js
@@ -80,9 +80,9 @@ stalePullRequest._processPullRequest = function (pullRequest, repositorySettings
             pullRequestDate = lastComment.updated_at;
         }
 
-        var foundStop = stalePullRequest.foundStopComment(commentsJsonResponse);
-        var daysSinceComment = stalePullRequest.daysSince(new Date(pullRequestDate));
-        var daysSinceLastCommit = stalePullRequest.daysSince(new Date(lastCommitDate));
+        var foundStop = stalePullRequest._foundStopComment(commentsJsonResponse);
+        var daysSinceComment = stalePullRequest._daysSince(new Date(pullRequestDate));
+        var daysSinceLastCommit = stalePullRequest._daysSince(new Date(lastCommitDate));
 
         var daysSinceUpdate = Math.min(daysSinceLastCommit, daysSinceComment);
 
@@ -104,22 +104,22 @@ stalePullRequest._processPullRequest = function (pullRequest, repositorySettings
 
     var commitsJsonResponse;
 
-    return stalePullRequest.getCommits(commitsUrl, repositorySettings)
+    return stalePullRequest._getCommits(commitsUrl, repositorySettings)
         .then(function (commits) {
             commitsJsonResponse = commits;
-            return stalePullRequest.getComments(commentsUrl, repositorySettings);
+            return stalePullRequest._getComments(commentsUrl, repositorySettings);
         })
         .then(function (commentsJsonResponse) {
             return checkForUpdates(commentsJsonResponse, commitsJsonResponse);
         });
 };
 
-stalePullRequest.daysSince = function (date) {
+stalePullRequest._daysSince = function (date) {
     var msPerDay = 24 * 60 * 60 * 1000;
     return (Date.now() - date.getTime()) / msPerDay;
 };
 
-stalePullRequest.foundStopComment = function (commentsJsonResponse) {
+stalePullRequest._foundStopComment = function (commentsJsonResponse) {
     for (var i = 0; i < commentsJsonResponse.length; i++){
         var comment = commentsJsonResponse[i].body.toLowerCase();
         var userName = commentsJsonResponse[i].user.login;
@@ -131,7 +131,7 @@ stalePullRequest.foundStopComment = function (commentsJsonResponse) {
     return false;
 };
 
-stalePullRequest.getCommits = function (commitsUrl, repositorySettings) {
+stalePullRequest._getCommits = function (commitsUrl, repositorySettings) {
     return requestPromise.get({
         url: commitsUrl,
         headers: repositorySettings.headers,
@@ -142,7 +142,7 @@ stalePullRequest.getCommits = function (commitsUrl, repositorySettings) {
     });
 };
 
-stalePullRequest.getComments = function (commentsUrl, repositorySettings) {
+stalePullRequest._getComments = function (commentsUrl, repositorySettings) {
     return requestPromise.get({
         url: commentsUrl,
         headers: repositorySettings.headers,

--- a/lib/stalePullRequest.js
+++ b/lib/stalePullRequest.js
@@ -145,4 +145,4 @@ stalePullRequest.getDaysSinceLastCommit = function (commitsUrl, repositorySettin
         var commitDate = commits[commits.length - 1].commit.author.date;
         return stalePullRequest.daysSince(new Date(commitDate));
     });
-}
+};

--- a/lib/stalePullRequest.js
+++ b/lib/stalePullRequest.js
@@ -67,11 +67,17 @@ stalePullRequest._processRepository = function (repositoryName, repositorySettin
 
 stalePullRequest._processPullRequest = function (pullRequest, repositorySettings) {
     var commentsUrl = pullRequest.comments_url + '?sort=updated';
+    var commitsUrl = pullRequest.commits_url;
+    var daysSinceLastCommit;
 
     function processComments(commentsJsonResponse) {
         var lastComment = commentsJsonResponse[commentsJsonResponse.length - 1];
+        var pullRequestDate = Cesium.defined(lastComment) ? lastComment.updated_at : pullRequest.updated_at;
         var foundStop = stalePullRequest.foundStopComment(commentsJsonResponse);
-        if (!foundStop && stalePullRequest.daysSince(new Date(lastComment.updated_at)) >= repositorySettings.maxDaysSinceUpdate) {
+        var daysSinceComment = stalePullRequest.daysSince(new Date(pullRequestDate));
+        var daysSinceUpdate = Math.min(daysSinceLastCommit, daysSinceComment);
+
+        if (!foundStop && daysSinceUpdate >= repositorySettings.maxDaysSinceUpdate) {
             var template = repositorySettings.stalePullRequestTemplate;
             return requestPromise.post({
                 url: commentsUrl,
@@ -87,12 +93,16 @@ stalePullRequest._processPullRequest = function (pullRequest, repositorySettings
         }
     }
 
-    return requestPromise.get({
-        url: commentsUrl,
-        headers: repositorySettings.headers,
-        json: true,
-        resolveWithFullResponse: true
-    })
+    return stalePullRequest.getDaysSinceLastCommit(commitsUrl, repositorySettings)
+    .then(function (response) {
+        daysSinceLastCommit = response;
+
+        return requestPromise.get({
+            url: commentsUrl,
+            headers: repositorySettings.headers,
+            json: true,
+            resolveWithFullResponse: true
+        })
         .then(function (response) {
             var linkData = parseLink(response.headers.link);
             if (Cesium.defined(linkData)) {
@@ -105,6 +115,7 @@ stalePullRequest._processPullRequest = function (pullRequest, repositorySettings
             }
             return processComments(response.body);
         });
+    });
 };
 
 stalePullRequest.daysSince = function (date) {
@@ -123,3 +134,15 @@ stalePullRequest.foundStopComment = function (commentsJsonResponse) {
 
     return false;
 };
+
+stalePullRequest.getDaysSinceLastCommit = function (commitsUrl, repositorySettings) {
+    return requestPromise.get({
+        url: commitsUrl,
+        headers: repositorySettings.headers,
+        json: true
+    })
+    .then(function (commits) {
+        var commitDate = commits[commits.length - 1].commit.author.date;
+        return stalePullRequest.daysSince(new Date(commitDate));
+    });
+}

--- a/lib/stalePullRequest.js
+++ b/lib/stalePullRequest.js
@@ -71,8 +71,15 @@ stalePullRequest._processPullRequest = function (pullRequest, repositorySettings
     var daysSinceLastCommit;
 
     function processComments(commentsJsonResponse) {
-        var lastComment = commentsJsonResponse[commentsJsonResponse.length - 1];
-        var pullRequestDate = Cesium.defined(lastComment) ? lastComment.updated_at : pullRequest.updated_at;
+        var pullRequestDate;
+        var lastComment;
+        if (commentsJsonResponse.length === 0) {
+            pullRequestDate = pullRequest.updated_at;
+        } else {
+            lastComment = commentsJsonResponse[commentsJsonResponse.length - 1];
+            pullRequestDate = lastComment.updated_at;
+        }
+
         var foundStop = stalePullRequest.foundStopComment(commentsJsonResponse);
         var daysSinceComment = stalePullRequest.daysSince(new Date(pullRequestDate));
         var daysSinceUpdate = Math.min(daysSinceLastCommit, daysSinceComment);

--- a/lib/stalePullRequest.js
+++ b/lib/stalePullRequest.js
@@ -68,11 +68,11 @@ stalePullRequest._processRepository = function (repositoryName, repositorySettin
 stalePullRequest._processPullRequest = function (pullRequest, repositorySettings) {
     var commentsUrl = pullRequest.comments_url + '?sort=updated';
     var commitsUrl = pullRequest.commits_url;
-    var daysSinceLastCommit;
 
-    function processComments(commentsJsonResponse) {
+    function checkForUpdates(commentsJsonResponse, commitsJsonResponse) {
         var pullRequestDate;
         var lastComment;
+        var lastCommitDate = commitsJsonResponse[commitsJsonResponse.length - 1].commit.author.date;
         if (commentsJsonResponse.length === 0) {
             pullRequestDate = pullRequest.updated_at;
         } else {
@@ -82,12 +82,14 @@ stalePullRequest._processPullRequest = function (pullRequest, repositorySettings
 
         var foundStop = stalePullRequest.foundStopComment(commentsJsonResponse);
         var daysSinceComment = stalePullRequest.daysSince(new Date(pullRequestDate));
+        var daysSinceLastCommit = stalePullRequest.daysSince(new Date(lastCommitDate));
+
         var daysSinceUpdate = Math.min(daysSinceLastCommit, daysSinceComment);
 
         if (!foundStop && daysSinceUpdate >= repositorySettings.maxDaysSinceUpdate) {
             var template = repositorySettings.stalePullRequestTemplate;
             return requestPromise.post({
-                url: commentsUrl,
+                url: pullRequest.comments_url,
                 headers: repositorySettings.headers,
                 body: {
                     body: template({
@@ -100,29 +102,16 @@ stalePullRequest._processPullRequest = function (pullRequest, repositorySettings
         }
     }
 
-    return stalePullRequest.getDaysSinceLastCommit(commitsUrl, repositorySettings)
-    .then(function (response) {
-        daysSinceLastCommit = response;
+    var commitsJsonResponse;
 
-        return requestPromise.get({
-            url: commentsUrl,
-            headers: repositorySettings.headers,
-            json: true,
-            resolveWithFullResponse: true
+    return stalePullRequest.getCommits(commitsUrl, repositorySettings)
+        .then(function (commits) {
+            commitsJsonResponse = commits;
+            return stalePullRequest.getComments(commentsUrl, repositorySettings);
         })
-        .then(function (response) {
-            var linkData = parseLink(response.headers.link);
-            if (Cesium.defined(linkData)) {
-                commentsUrl = linkData.last.url;
-                return requestPromise.get({
-                    url: commentsUrl,
-                    headers: repositorySettings.headers,
-                    json: true,
-                }).then(processComments);
-            }
-            return processComments(response.body);
+        .then(function (commentsJsonResponse) {
+            return checkForUpdates(commentsJsonResponse, commitsJsonResponse);
         });
-    });
 };
 
 stalePullRequest.daysSince = function (date) {
@@ -142,14 +131,37 @@ stalePullRequest.foundStopComment = function (commentsJsonResponse) {
     return false;
 };
 
-stalePullRequest.getDaysSinceLastCommit = function (commitsUrl, repositorySettings) {
+stalePullRequest.getCommits = function (commitsUrl, repositorySettings) {
     return requestPromise.get({
         url: commitsUrl,
         headers: repositorySettings.headers,
         json: true
     })
     .then(function (commits) {
-        var commitDate = commits[commits.length - 1].commit.author.date;
-        return stalePullRequest.daysSince(new Date(commitDate));
+        return commits;
+    });
+};
+
+stalePullRequest.getComments = function (commentsUrl, repositorySettings) {
+    return requestPromise.get({
+        url: commentsUrl,
+        headers: repositorySettings.headers,
+        json: true,
+        resolveWithFullResponse: true
+    })
+    .then(function (response) {
+        var linkData = parseLink(response.headers.link);
+        if (Cesium.defined(linkData)) {
+            var lastUrl = linkData.last.url;
+            return requestPromise.get({
+                url: lastUrl,
+                headers: repositorySettings.headers,
+                json: true,
+            })
+            .then(function (comments) {
+                return comments;
+            });
+        }
+        return response.body;
     });
 };

--- a/specs/lib/stalePullRequestSpec.js
+++ b/specs/lib/stalePullRequestSpec.js
@@ -102,7 +102,7 @@ describe('stalePullRequest', function () {
             return Promise.reject(new Error('Unexpected Url: ' + options.url));
         });
         spyOn(requestPromise, 'post');
-        spyOn(stalePullRequest, 'foundStopComment').and.callFake(function () {
+        spyOn(stalePullRequest, '_foundStopComment').and.callFake(function () {
             return false;
         });
 
@@ -147,7 +147,7 @@ describe('stalePullRequest', function () {
             return Promise.reject(new Error('Unexpected Url: ' + options.url));
         });
         spyOn(requestPromise, 'post');
-        spyOn(stalePullRequest, 'foundStopComment').and.callFake(function () {
+        spyOn(stalePullRequest, '_foundStopComment').and.callFake(function () {
             return false;
         });
 
@@ -199,7 +199,7 @@ describe('stalePullRequest', function () {
             return Promise.reject(new Error('Unexpected Url: ' + options.url));
         });
         spyOn(requestPromise, 'post');
-        spyOn(stalePullRequest, 'foundStopComment').and.callFake(function () {
+        spyOn(stalePullRequest, '_foundStopComment').and.callFake(function () {
             return false;
         });
 
@@ -238,7 +238,7 @@ describe('stalePullRequest', function () {
             return Promise.reject(new Error('Unexpected Url: ' + options.url));
         });
         spyOn(requestPromise, 'post');
-        spyOn(stalePullRequest, 'foundStopComment').and.callFake(function () {
+        spyOn(stalePullRequest, '_foundStopComment').and.callFake(function () {
             return true;
         });
 
@@ -254,13 +254,13 @@ describe('stalePullRequest', function () {
         var conciergeUser = {login: 'cesium-concierge'};
         var otherUser = {login: 'BobDylan'};
 
-        expect(stalePullRequest.foundStopComment([{ body: '', user: otherUser }])).toBe(false);
-        expect(stalePullRequest.foundStopComment([{ body: '', user: conciergeUser }])).toBe(false);
-        expect(stalePullRequest.foundStopComment([{ body: '@cesium-concierge stop', user: conciergeUser }])).toBe(false);
-        expect(stalePullRequest.foundStopComment([{ body: 'This is a profound PR.', user: otherUser }])).toBe(false);
+        expect(stalePullRequest._foundStopComment([{ body: '', user: otherUser }])).toBe(false);
+        expect(stalePullRequest._foundStopComment([{ body: '', user: conciergeUser }])).toBe(false);
+        expect(stalePullRequest._foundStopComment([{ body: '@cesium-concierge stop', user: conciergeUser }])).toBe(false);
+        expect(stalePullRequest._foundStopComment([{ body: 'This is a profound PR.', user: otherUser }])).toBe(false);
 
-        expect(stalePullRequest.foundStopComment([{ body: '@cesium-concierge stop', user: otherUser }])).toBe(true);
-        expect(stalePullRequest.foundStopComment([{ body: '', user: conciergeUser }, { body: '@cesium-concierge stop', user: otherUser }])).toBe(true);
+        expect(stalePullRequest._foundStopComment([{ body: '@cesium-concierge stop', user: otherUser }])).toBe(true);
+        expect(stalePullRequest._foundStopComment([{ body: '', user: conciergeUser }, { body: '@cesium-concierge stop', user: otherUser }])).toBe(true);
     });
 
 });

--- a/specs/lib/stalePullRequestSpec.js
+++ b/specs/lib/stalePullRequestSpec.js
@@ -135,7 +135,9 @@ describe('stalePullRequest', function () {
             } else if (options.url === commentsUrl + '?page=3') {
                 return Promise.resolve([{
                     updated_at: timestamp,
-                    user: {login: 'boomerjones'}
+                    user: {
+                        login: 'boomerjones'
+                    }
                 }]);
             } else if (options.url === commitsUrl) {
                 var commitsDataOld = JSON.parse(JSON.stringify(commitsData));
@@ -152,7 +154,7 @@ describe('stalePullRequest', function () {
         stalePullRequest._processPullRequest(pullRequest, repositorySettings)
             .then(function () {
                 expect(requestPromise.post).toHaveBeenCalledWith({
-                    url: commentsUrl + '?page=3',
+                    url: commentsUrl,
                     headers: repositorySettings.headers,
                     body: {
                         body: repositorySettings.stalePullRequestTemplate({
@@ -174,7 +176,9 @@ describe('stalePullRequest', function () {
         var pullRequest = {
             comments_url: commentsUrl,
             commits_url: commitsUrl,
-            user: {login: 'boomerjones'}
+            user: {
+                login: 'boomerjones'
+            }
         };
 
         spyOn(requestPromise, 'get').and.callFake(function (options) {
@@ -224,7 +228,9 @@ describe('stalePullRequest', function () {
                 timestamp.setDate(timestamp.getDate() - repositorySettings.maxDaysSinceUpdate);
                 return Promise.resolve([{
                     updated_at: timestamp,
-                    user: {login: 'boomerjones'}
+                    user: {
+                        login: 'boomerjones'
+                    }
                 }]);
             } else if (options.url === commitsUrl) {
                 return Promise.resolve(commitsData);

--- a/specs/lib/stalePullRequestSpec.js
+++ b/specs/lib/stalePullRequestSpec.js
@@ -10,16 +10,6 @@ describe('stalePullRequest', function () {
     var repositories;
     var commitsData;
 
-    beforeAll(function () {
-        commitsData = [{
-            commit: {
-                author: {
-                    date: new Date(Date.now())
-                }
-            }
-        }];
-    });
-
     beforeEach(function () {
         repositories = {
             'AnalyticalGraphics/cesium': new RepositorySettings({
@@ -29,6 +19,14 @@ describe('stalePullRequest', function () {
                 gitHubToken: 'token2'
             })
         };
+
+        commitsData = [{
+            commit: {
+                author: {
+                    date: new Date(Date.now())
+                }
+            }
+        }];
     });
 
     it('calls stalePullRequest._processRepository once for each repository', function (done) {
@@ -123,7 +121,9 @@ describe('stalePullRequest', function () {
         var pullRequest = {
             comments_url: commentsUrl,
             commits_url: commitsUrl,
-            user: {login: 'boomerjones'}
+            user: {
+                login: 'boomerjones'
+            }
         };
 
         var timestamp = new Date(Date.now());
@@ -185,7 +185,9 @@ describe('stalePullRequest', function () {
                 timestamp.setDate(timestamp.getDate() - repositorySettings.maxDaysSinceUpdate);
                 return Promise.resolve([{
                     updated_at: timestamp,
-                    user: {login: 'boomerjones'}
+                    user: {
+                        login: 'boomerjones'
+                    }
                 }]);
             } else if (options.url === commitsUrl) {
                 return Promise.resolve(commitsData);


### PR DESCRIPTION
This implements https://github.com/AnalyticalGraphicsInc/cesium-concierge/issues/60. The bumper will now fetch the commits on a PR, check the date of the latest one, and if both that date and the date of the last comment are more than X number of days, it will bump.

This also fixes an edge case where a PR has no comments, concierge would crash (this is unlikely to ever happen since there will almost always be at least the concierge's initial comment) but it was easy enough to fix. If there are no comments it will use the PR's created_at date.

I added a spec to test that it will not bump if there is a recent commit. 