### PR TITLE
Bumper start script no longer needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "yargs": "^8.0.2"
   },
   "scripts": {
-    "bumper": "node ./bin/stalePullRequest.js",
     "create-zip": "gulp create-zip",
     "eslint": "eslint . --cache",
     "start": "node index.js",


### PR DESCRIPTION
I didn't realize the bumper had an `npm` start script. Since it's part of the application now this is no longer needed.

@ggetz 