### PR TITLE
Add timezone setting

### DIFF
--- a/.ebextensions/timezone.config
+++ b/.ebextensions/timezone.config
@@ -1,3 +1,0 @@
-commands:
-	set_timezone:
-		command: cp /usr/share/zoneinfo/America/New_York /etc/localtime

--- a/.ebextensions/timezone.config
+++ b/.ebextensions/timezone.config
@@ -1,0 +1,3 @@
+commands:
+	set_timezone:
+		command: cp /usr/share/zoneinfo/America/New_York /etc/localtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ EXPOSE 5000
 COPY . /var/app
 WORKDIR /var/app
 
+RUN apk add --no-cache tzdata
+ENV TZ America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN apk add --update nano bash \
   && rm -rf /tmp/* /var/cache/apk/* \
   && npm install \


### PR DESCRIPTION
Currently concierge runs on an AWS server by default configured for UTC time. This makes the script bumper run at 5 pm our time instead of midnight. Which isn't a big deal, but our Slackbot will also be running on the same server and it'd be nice to post things in the morning in a timely manner.

This will set the correct timezone inside the Docker container. Since we're using a stripped down version of Linux (alpine) we need to install `tzdata` for timezones to work.

@ggetz 