### PR TITLE
Make sure Slackbot actually calls Slack API

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -90,9 +90,11 @@ SlackBot.postMessage = function(channelId, message) {
     return Promise.resolve('Warning: SlackBot is disabled.');
   }
 
+  var that = this;
+
   return this._readyPromise
     .then(function () {
-      return this._slackClient.chat.postMessage({
+      return that._slackClient.chat.postMessage({
         channel: channelId,
         text: message,
         as_user: true

--- a/specs/lib/SlackBotSpec.js
+++ b/specs/lib/SlackBotSpec.js
@@ -445,4 +445,23 @@ describe('SlackBot', function () {
             })
             .catch(done.fail);
     });
+
+    fit('postMessage calls the Slack API.', function () {
+        spyOn(SlackBot, '_authenticateGitHub');
+        spyOn(SlackBot, '_getSlackMetadata').and.callFake(function() {
+            return Promise.resolve();
+        });
+
+        SlackBot.init({
+            token: 'token',
+            configUrl: configUrl,
+            repositories: repositories
+        });
+
+        spyOn(SlackBot._slackClient.chat, 'postMessage');
+        return SlackBot.postMessage()
+            .then(function() {
+                expect(SlackBot._slackClient.chat.postMessage).toHaveBeenCalled();
+            });
+    });
 });

--- a/specs/lib/SlackBotSpec.js
+++ b/specs/lib/SlackBotSpec.js
@@ -446,7 +446,7 @@ describe('SlackBot', function () {
             .catch(done.fail);
     });
 
-    fit('postMessage calls the Slack API.', function () {
+    it('postMessage calls the Slack API.', function () {
         spyOn(SlackBot, '_authenticateGitHub');
         spyOn(SlackBot, '_getSlackMetadata').and.callFake(function() {
             return Promise.resolve();


### PR DESCRIPTION
This was totally my bad, but the Slack bot's unit tests weren't actually checking if it calls the Slack API so it missed a typo/syntax error.