### PR TITLE
Only report last week's PRs in weekly stats

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -126,7 +126,7 @@ SlackBot._getAllPullRequestsMergedLastWeek = function(repositoryNames) {
     return that._githubClient.pulls.checkIfMerged({
       owner : urlParts[0],
       repo : urlParts[1],
-      number : urlParts[3]
+      pull_number : urlParts[3]
     })
       .then(function(result) {
         if (result.status === 204) {

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var WebClient = require('@slack/client').WebClient;
-var octokit = require('@octokit/rest')();
+var Octokit = require('@octokit/rest');
 var YAML = require('yaml');
 var requestPromise = require('request-promise');
 var schedule = require('node-schedule');
@@ -43,9 +43,8 @@ SlackBot.init = function(options) {
   }
 
   this._slackClient = new WebClient(this._token);
-
   // Authenticate using the first token found.
-  this._authenticateGitHub();
+  this._githubClient = this._authenticateGitHub();
 
   this._readyPromise = this._getSlackMetadata()
     .catch(function(error) {
@@ -102,110 +101,120 @@ SlackBot.postMessage = function(channelId, message) {
     });
 };
 
-SlackBot._getAllIssuesLastWeek = function(repositoryNames, octokitReference) {
-  // octokitReference makes it easier to test this function by passing in a stubbed version of the library.
+SlackBot._getAllPullRequestsMergedLastWeek = function(repositoryNames) {
   // Given a list of repository names, return a list of promises that resolve to
-  // a list of all closed issues/PR's last week.
-  var promisesArray = [];
+  // a list of all PR's merged last week.
+  var pullRequests = [];
+  var repositoryPromises = [];
+  var that = this;
+  var today = moment().startOf('day');
+
+  function processRepositoryIssues(issue) {
+    // Filter out issues that are not pull requests, and anything whose closed_at date is older than a week.
+    var pullRequest = issue.pull_request;
+    if (!defined(pullRequest)) {
+      return;
+    }
+
+    var closedTime = moment(issue.closed_at);
+    if (today.diff(closedTime, 'days') > 7) {
+      return;
+    }
+
+    // Filter out anything that was not merged.
+    var urlParts = pullRequest.url.replace('https://api.github.com/repos/', '').split('/');
+    return that._githubClient.pulls.checkIfMerged({
+      owner : urlParts[0],
+      repo : urlParts[1],
+      number : urlParts[3]
+    })
+      .then(function(result) {
+        if (result.status === 204) {
+          pullRequests.push(issue);
+        }
+      })
+      .catch(function() {
+        // Will 404 if the PR wasn't merged.
+      });
+  }
+
   for (var i = 0; i < repositoryNames.length; ++i) {
       var nameSplit = repositoryNames[i].split('/');
       var owner = nameSplit[0];
       var repo = nameSplit[1];
       // Get all closed issues/PRs for this repo for last week.
       var lastWeek = moment().subtract(7, 'days');
-      var options = octokitReference.issues.listForRepo.endpoint.merge({
+      var options = this._githubClient.issues.listForRepo.endpoint.merge({
         owner: owner,
         repo: repo,
         since: lastWeek.format(),
         state: 'closed'
       });
-      promisesArray.push(octokitReference.paginate(options));
+
+      var repositoryIssuesPromise = Promise.each(this._githubClient.paginate(options), processRepositoryIssues);
+      repositoryPromises.push(repositoryIssuesPromise);
   }
 
-  return Promise.all(promisesArray)
-    .then(function(listsOfIssues) {
-      // Since the GitHub API returns anything created or updated last week,
-      // we remove anything whose closed_at date is older than a week.
-      var filteredList = [];
-      var today = moment().startOf('day');
-
-      for(var i = 0; i < listsOfIssues.length; ++i) {
-        var newList = [];
-        for (var j = 0; j < listsOfIssues[i].length; ++j) {
-          var issue = listsOfIssues[i][j];
-          var closedTime = moment(issue.closed_at);
-          if (today.diff(closedTime, 'days') <= 7) {
-            newList.push(issue);
-          }
-        }
-
-        filteredList.push(newList);
-      }
-
-      return filteredList;
+  return Promise.all(repositoryPromises)
+    .then(function() {
+      return pullRequests;
     });
 };
 
 SlackBot._sendWeeklyStats = function() {
     var repositoryNames = Object.keys(this._repositories);
-    var issuePromises = this._getAllIssuesLastWeek(repositoryNames, octokit);
-
     var longestMergeTime = 0;
     var longestPullRequest;
     var mergeTimes = [];
     var that = this;
 
-    // Each promise here is a list of issues from one repository.
-    return Promise.each(issuePromises, function(issues) {
-      issues.forEach(function(issue) {
-        if (defined(issue.pull_request)) {
-          var endTime = moment(issue.closed_at);
-          var startTime = moment(issue.created_at);
+    return Promise.each(this._getAllPullRequestsMergedLastWeek(repositoryNames),
+      function(pullRequest) {
+          var endTime = moment(pullRequest.closed_at);
+          var startTime = moment(pullRequest.created_at);
           var daysDifference = endTime.diff(startTime, 'days');
           mergeTimes.push(daysDifference);
 
           if (!defined(longestPullRequest) || daysDifference > longestMergeTime) {
-            longestPullRequest = issue;
+            longestPullRequest = pullRequest;
             longestMergeTime = daysDifference;
           }
+      })
+      .then(function() {
+        return that._getConfig();
+      })
+      .then(function(slackBotSettings) {
+        var greetings = slackBotSettings.greetings;
+        if (!defined(greetings)) {
+          greetings = ['Happy Friday everyone!'];
         }
+
+        var averageMergeTime = getAverage(mergeTimes).toFixed(1);
+        longestMergeTime = longestMergeTime.toFixed(1);
+
+        // Compute the standard deviation. If the longest merge time is more than 3 times that, report is as unusual.
+        var deviation = getStandardDeviation(mergeTimes);
+        var longMergeTitle;
+
+        if (Math.abs(longestMergeTime - averageMergeTime) >= deviation * 2) {
+          longMergeTitle = longestPullRequest.title;
+        }
+
+        var greeting = greetings[Math.floor(Math.random() * greetings.length)];
+        var templateName = 'weeklyStats';
+        var template = fs.readFileSync(path.join(__dirname, 'templates', templateName + '.hbs')).toString();
+
+        var messageText = handlebars.compile(template)({
+          greeting : greeting,
+          averageMergeTime : averageMergeTime,
+          numberOfPullRequests : mergeTimes.length,
+          longMergeTitle : longMergeTitle,
+          longMergeTime : longestMergeTime,
+          longMergeURL : longestPullRequest.html_url
+        });
+
+        return that.postMessage(that._channelIDs['general'], messageText);
       });
-    })
-    .then(function() {
-      return that._getConfig();
-    })
-    .then(function(slackBotSettings) {
-      var greetings = slackBotSettings.greetings;
-      if (!defined(greetings)) {
-        greetings = ['Happy Friday everyone!'];
-      }
-
-      var averageMergeTime = getAverage(mergeTimes).toFixed(1);
-      longestMergeTime = longestMergeTime.toFixed(1);
-
-      // Compute the standard deviation. If the longest merge time is more than 3 times that, report is as unusual.
-      var deviation = getStandardDeviation(mergeTimes);
-      var longMergeTitle;
-
-      if (Math.abs(longestMergeTime - averageMergeTime) >= deviation * 2) {
-        longMergeTitle = longestPullRequest.title;
-      }
-
-      var greeting = greetings[Math.floor(Math.random() * greetings.length)];
-      var templateName = 'weeklyStats';
-      var template = fs.readFileSync(path.join(__dirname, 'templates', templateName + '.hbs')).toString();
-
-      var messageText = handlebars.compile(template)({
-        greeting : greeting,
-        averageMergeTime : averageMergeTime,
-        numberOfPullRequests : mergeTimes.length,
-        longMergeTitle : longMergeTitle,
-        longMergeTime : longestMergeTime,
-        longMergeURL : longestPullRequest.html_url
-      });
-
-      return that.postMessage(that._channelIDs['general'], messageText);
-    });
 };
 
 SlackBot._sendReleaseReminders = function() {
@@ -342,9 +351,8 @@ SlackBot._getAllUsers = function() {
 
 SlackBot._authenticateGitHub = function() {
   var repositoryNames = Object.keys(this._repositories);
-  octokit.authenticate({
-    type: 'token',
-    token: this._repositories[repositoryNames[0]].gitHubToken
+  return new Octokit({
+    auth: 'token ' + this._repositories[repositoryNames[0]].gitHubToken
   });
 };
 

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -133,8 +133,8 @@ SlackBot._getAllIssuesLastWeek = function(repositoryNames, octokitReference) {
         var newList = [];
         for (var j = 0; j < listsOfIssues[i].length; ++j) {
           var issue = listsOfIssues[i][j];
-          var createdTime = moment(issue.closed_at);
-          if (today.diff(createdTime, 'days') <= 7) {
+          var closedTime = moment(issue.closed_at);
+          if (today.diff(closedTime, 'days') <= 7) {
             newList.push(issue);
           }
         }

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -122,7 +122,28 @@ SlackBot._getAllIssuesLastWeek = function(repositoryNames, octokitReference) {
       promisesArray.push(octokitReference.paginate(options));
   }
 
-  return promisesArray;
+  return Promise.all(promisesArray)
+    .then(function(listsOfIssues) {
+      // Since the GitHub API returns anything created or updated last week,
+      // we remove anything whose closed_at date is older than a week.
+      var filteredList = [];
+      var today = moment().startOf('day');
+
+      for(var i = 0; i < listsOfIssues.length; ++i) {
+        var newList = [];
+        for (var j = 0; j < listsOfIssues[i].length; ++j) {
+          var issue = listsOfIssues[i][j];
+          var createdTime = moment(issue.closed_at);
+          if (today.diff(createdTime, 'days') <= 7) {
+            newList.push(issue);
+          }
+        }
+
+        filteredList.push(newList);
+      }
+
+      return filteredList;
+    });
 };
 
 SlackBot._sendWeeklyStats = function() {

--- a/lib/commentOnClosedIssue.js
+++ b/lib/commentOnClosedIssue.js
@@ -58,7 +58,6 @@ commentOnClosedIssue._implementation = function (options) {
 
     var comments = [];
     var issueHtmlUrl;
-    var isFirstContribution;
 
     return repositorySettings.fetchSettings()
         .then(function () {
@@ -86,10 +85,6 @@ commentOnClosedIssue._implementation = function (options) {
             });
         })
         .then(function () {
-            return commentOnClosedIssue._isFirstContribution(userName, repositorySettings, baseBranch, baseApiUrl);
-        })
-        .then(function (result) {
-            isFirstContribution = result;
             return requestPromise.get({
                 url: commentsUrl,
                 headers: repositorySettings.headers,
@@ -104,7 +99,7 @@ commentOnClosedIssue._implementation = function (options) {
             var forum_links = getUniqueMatch(comments, commentOnClosedIssue._googleLinkRegex);
             var foundForumLinks = forum_links.length !== 0;
 
-            if (!foundForumLinks && !isFirstContribution) {
+            if (!foundForumLinks) {
                 return Promise.resolve();
             }
 
@@ -115,7 +110,6 @@ commentOnClosedIssue._implementation = function (options) {
                     body: repositorySettings.issueClosedTemplate({
                         html_url: issueHtmlUrl,
                         forum_links: forum_links,
-                        isFirstContribution: isFirstContribution,
                         foundForumLinks: foundForumLinks,
                         userName: userName
                     })
@@ -131,26 +125,5 @@ commentOnClosedIssue._implementation = function (options) {
             }
         });
 };
-
-commentOnClosedIssue._isFirstContribution = function (userName, repositorySettings, baseBranch, baseApiUrl) {
-    // This is a user's first contribution if the repo/branch they're merging _into_ does not have their name in the contributors.
-    if (!defined(repositorySettings.contributorsPath)) {
-        return Promise.resolve(false);
-    }
-
-    var url = baseApiUrl + '/contents/' + repositorySettings.contributorsPath + '?ref=' + baseBranch;
-
-    return requestPromise.get({
-        url: url,
-        headers: repositorySettings.headers,
-        json: true
-    })
-    .then(function (response) {
-        var contributorsFileContent = Buffer.from(response.content, 'base64').toString();
-        var matchResults = contributorsFileContent.match(new RegExp('/' + userName + '\\)', 'g'));
-        return !defined(matchResults);
-    });
-};
-
 
 commentOnClosedIssue._googleLinkRegex = /https?:\/\/groups\.google\.com\/[^\s.,:)\\]*cesium-dev\/[^\s.,:)\\]+/ig;

--- a/lib/commentOnClosedIssue.js
+++ b/lib/commentOnClosedIssue.js
@@ -76,12 +76,20 @@ commentOnClosedIssue._implementation = function (options) {
             if (!isPullRequest) {
                 return Promise.resolve(false);
             }
+
+            // Check if this PR was merged, since the GitHub API returns "closed" for BOTH merged or closed.
+            // This returns an error if the PR was NOT merged.
+            return requestPromise.get({
+                url: issueUrl + '/merge',
+                headers: repositorySettings.headers,
+                json: true
+            });
+        })
+        .then(function () {
             return commentOnClosedIssue._isFirstContribution(userName, repositorySettings, baseBranch, baseApiUrl);
         })
         .then(function (result) {
             isFirstContribution = result;
-        })
-        .then(function () {
             return requestPromise.get({
                 url: commentsUrl,
                 headers: repositorySettings.headers,
@@ -114,6 +122,13 @@ commentOnClosedIssue._implementation = function (options) {
                 },
                 json: true
             });
+        })
+        .catch(function(error) {
+            // We expect a 404 if a PR was closed and not merged.
+            // Otherwise, propagate the error
+            if (error.name !== 'StatusCodeError' || error.statusCode !== 404) {
+                throw error;
+            }
         });
 };
 
@@ -132,7 +147,8 @@ commentOnClosedIssue._isFirstContribution = function (userName, repositorySettin
     })
     .then(function (response) {
         var contributorsFileContent = Buffer.from(response.content, 'base64').toString();
-        return contributorsFileContent.indexOf(userName) === -1;
+        var matchResults = contributorsFileContent.match(new RegExp('/' + userName + '\\)', 'g'));
+        return !defined(matchResults);
     });
 };
 

--- a/lib/commentOnClosedIssue.js
+++ b/lib/commentOnClosedIssue.js
@@ -30,8 +30,6 @@ function commentOnClosedIssue(body, repositorySettings) {
     if (defined(pullRequest)) {
         options.url = pullRequest.url;
         options.isPullRequest = true;
-        options.baseBranch = pullRequest.base.ref;
-        options.baseApiUrl = pullRequest.base.repo.url;
         options.commentsUrl = pullRequest.comments_url;
         options.userName = pullRequest.user.login;
     } else if (defined(issue)) {
@@ -51,8 +49,6 @@ commentOnClosedIssue._implementation = function (options) {
     var issueUrl = options.url;
     var commentsUrl = options.commentsUrl;
     var isPullRequest = options.isPullRequest;
-    var baseBranch = options.baseBranch;
-    var baseApiUrl = options.baseApiUrl;
     var userName = options.userName;
     var repositorySettings = options.repositorySettings;
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "@octokit/rest": "^16.3.0",
+    "@octokit/rest": "^16.16.0",
     "@slack/client": "^4.8.0",
     "bluebird": "^3.0.0",
     "body-parser": "^1.0.0",

--- a/specs/lib/SlackBotSpec.js
+++ b/specs/lib/SlackBotSpec.js
@@ -350,9 +350,9 @@ describe('SlackBot', function () {
             return {};
         });
         spyOn(octokit, 'paginate').and.callFake(function() {
-            return Promise.resolve({
+            return Promise.resolve([[{
                 isIssue: true
-            });
+            }]]);
         });
 
         var promiseArray = SlackBot._getAllIssuesLastWeek(repositoryNames, octokit);
@@ -368,8 +368,8 @@ describe('SlackBot', function () {
 
         expect(octokit.issues.listForRepo.endpoint.merge.calls.length).toEqual(repositories.length);
 
-        Promise.each(promiseArray, function(issue) {
-            expect(issue.isIssue).toBe(true);
+        Promise.each(promiseArray, function(listsOfIssues) {
+            expect(listsOfIssues[0][0].isIssue).toBe(true);
         })
             .then(function () {
                 done();

--- a/specs/lib/SlackBotSpec.js
+++ b/specs/lib/SlackBotSpec.js
@@ -399,7 +399,7 @@ describe('SlackBot', function () {
             expect(SlackBot._githubClient.pulls.checkIfMerged).toHaveBeenCalledWith({
                 owner: 'owner',
                 repo: 'repo',
-                number: pullRequestNumber
+                pull_number: pullRequestNumber
             });
             // We expect one from each repo.
             expect(pullRequests.length).toBe(2);

--- a/specs/lib/commentOnClosedIssueSpec.js
+++ b/specs/lib/commentOnClosedIssueSpec.js
@@ -182,7 +182,6 @@ describe('commentOnClosedIssue', function () {
                             html_url: 'html_url',
                             forum_links: forumLinks,
                             foundForumLinks: true,
-                            isFirstContribution: true,
                             userName: userName
                         })
                     },
@@ -200,19 +199,7 @@ describe('commentOnClosedIssue', function () {
         ];
         runTestWithLinks(forumLinks)
             .then(function () {
-                expect(requestPromise.post).toHaveBeenCalledWith({
-                    url: 'commentsUrl',
-                    headers: repositorySettings.headers,
-                    body: {
-                        body: repositorySettings.issueClosedTemplate({
-                            html_url: 'html_url',
-                            foundForumLinks: false,
-                            isFirstContribution: true,
-                            userName: userName
-                        })
-                    },
-                    json: true
-                });
+                expect(requestPromise.post).not.toHaveBeenCalled();
                 done();
             })
             .catch(done.fail);
@@ -285,117 +272,6 @@ describe('commentOnClosedIssue', function () {
                 expect(requestPromise.post).not.toHaveBeenCalled();
                 done();
             });
-    });
-
-    it('commentOnClosedIssue._implementation posts about first timer\'s contribution.', function (done) {
-        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
-            return Promise.resolve(repositorySettings);
-        });
-        spyOn(requestPromise, 'get').and.callFake(function (options) {
-            if (options.url === issueUrl) {
-                return Promise.resolve(pullRequestEventJson);
-            }
-            if (options.url === isMergedUrl) {
-                return Promise.resolve();
-            }
-
-            if (options.url === contributorsUrl) {
-                return Promise.resolve(contributorsResponse);
-            }
-
-            if (options.url === commentsUrl) {
-                return Promise.resolve([]);
-            }
-
-            return Promise.reject('Unknown url: ' + options.url);
-        });
-        spyOn(requestPromise, 'post');
-
-        commentOnClosedIssue._implementation(commonOptions)
-            .then(function () {
-                expect(requestPromise.post).toHaveBeenCalledWith({
-                    url: commentsUrl,
-                    headers: repositorySettings.headers,
-                    body: {
-                        body: repositorySettings.issueClosedTemplate({
-                            isFirstContribution: true,
-                            userName: userName
-                        })
-                    },
-                    json: true
-                });
-                done();
-            })
-            .catch(done.fail);
-    });
-
-    it('commentOnClosedIssue._implementation does not post first timers message if not first time.', function (done) {
-        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
-            return Promise.resolve(repositorySettings);
-        });
-        spyOn(requestPromise, 'get').and.callFake(function (options) {
-            if (options.url === issueUrl) {
-                return Promise.resolve(pullRequestEventJson);
-            }
-            if (options.url === isMergedUrl) {
-                return Promise.resolve();
-            }
-
-            if (options.url === contributorsUrl) {
-                var content = Buffer.from('* [Jane Doe](https://github.com/JaneDoe)\n* [Boomer Jones](https://github.com/' + userName + ')').toString('base64');
-                return Promise.resolve({
-                    content: content
-                });
-            }
-
-            if (options.url === commentsUrl) {
-                return Promise.resolve([]);
-            }
-
-            return Promise.reject('Unknown url: ' + options.url);
-        });
-        spyOn(requestPromise, 'post');
-
-        commentOnClosedIssue._implementation(commonOptions)
-            .then(function () {
-                expect(requestPromise.post).not.toHaveBeenCalled();
-                done();
-            })
-            .catch(done.fail);
-    });
-
-    it('commentOnClosedIssue._implementation does not post anything for closed PRs.', function (done) {
-        spyOn(repositorySettings, 'fetchSettings').and.callFake(function() {
-            return Promise.resolve(repositorySettings);
-        });
-        spyOn(requestPromise, 'get').and.callFake(function (options) {
-            if (options.url === issueUrl) {
-                return Promise.resolve(pullRequestEventJson);
-            }
-            if (options.url === isMergedUrl) {
-                return Promise.reject({
-                    name: 'StatusCodeError',
-                    statusCode: 404
-                });
-            }
-            if (options.url === contributorsUrl) {
-                return Promise.resolve(contributorsResponse);
-            }
-
-            if (options.url === commentsUrl) {
-                return Promise.resolve([]);
-            }
-
-            return Promise.reject('Unknown url: ' + options.url);
-        });
-        spyOn(requestPromise, 'post');
-
-        commentOnClosedIssue._implementation(commonOptions)
-            .then(function () {
-                expect(requestPromise.post).not.toHaveBeenCalled();
-                done();
-            })
-            .catch(done.fail);
     });
 
     it('commentOnClosedIssue._implementation propagates unexpected errors.', function (done) {

--- a/specs/lib/commentOnClosedIssueSpec.js
+++ b/specs/lib/commentOnClosedIssueSpec.js
@@ -13,13 +13,9 @@ describe('commentOnClosedIssue', function () {
 
     var issueEventJson;
     var pullRequestEventJson;
-    var contributorsResponse;
     var issueUrl = 'issueUrl';
     var commentsUrl = 'commentsUrl';
     var isMergedUrl = issueUrl + '/merge';
-    var baseBranch = 'master';
-    var baseApiUrl = 'https://api.github.com/repos/AnalyticalGraphicsInc/cesium';
-    var contributorsUrl = baseApiUrl + '/contents/' + repositorySettings.contributorsPath + '?ref=' + baseBranch;
     var userName = 'Joan';
 
     beforeEach(function () {
@@ -28,8 +24,6 @@ describe('commentOnClosedIssue', function () {
             commentsUrl: commentsUrl,
             repositorySettings: repositorySettings,
             isPullRequest: true,
-            baseBranch: baseBranch,
-            baseApiUrl: baseApiUrl,
             userName: userName
         };
 
@@ -50,14 +44,9 @@ describe('commentOnClosedIssue', function () {
                 base: {
                     ref: 'master',
                     repo: {
-                        url: baseApiUrl
                     }
                 }
             }
-        };
-
-        contributorsResponse = {
-            content: Buffer.from('* [Jane Doe](https://github.com/JaneDoe)').toString('base64')
         };
     });
 
@@ -104,8 +93,6 @@ describe('commentOnClosedIssue', function () {
             url: issueUrl,
             commentsUrl: commentsUrl,
             isPullRequest: isPullRequest,
-            baseBranch: baseBranch,
-            baseApiUrl: baseApiUrl,
             userName: userName,
             repositorySettings: repositorySettings
         });
@@ -135,10 +122,6 @@ describe('commentOnClosedIssue', function () {
             if (options.url === commentsUrl) {
                 return Promise.resolve(commentsJson);
             }
-            if (options.url === contributorsUrl) {
-                return Promise.resolve(contributorsResponse);
-            }
-
             return Promise.reject('Unknown url: ' + options.url);
         });
         spyOn(requestPromise, 'post');
@@ -148,8 +131,6 @@ describe('commentOnClosedIssue', function () {
             commentsUrl: commentsUrl,
             repositorySettings: repositorySettings,
             isPullRequest: true,
-            baseBranch: baseBranch,
-            baseApiUrl: baseApiUrl,
             userName: userName
         });
     }
@@ -254,9 +235,6 @@ describe('commentOnClosedIssue', function () {
             if (options.url === isMergedUrl) {
                 return Promise.resolve();
             }
-            if (options.url === contributorsUrl) {
-                return Promise.resolve(contributorsResponse);
-            }
             if (options.url === commentsUrl) {
                 return Promise.reject('Bad request');
             }
@@ -284,9 +262,6 @@ describe('commentOnClosedIssue', function () {
             }
             if (options.url === isMergedUrl) {
                 return Promise.reject('Unexpected Error');
-            }
-            if (options.url === contributorsUrl) {
-                return Promise.resolve(contributorsResponse);
             }
 
             if (options.url === commentsUrl) {


### PR DESCRIPTION
This fixes https://github.com/AnalyticalGraphicsInc/cesium-concierge/issues/135 and adds a test to ensure that it works.

Slackbot will currently report that a PR was merged last week even if it was merged a long time ago, but someone commented on it last week. The other problem is getting a list of pull requests doesn't differentiate `merged` from `closed`. In order to check if a `PR` is merged or not we need to make another API request. This complicated the code a bit so I refactored it should be a lot simpler now. 

While working on this I also noticed the way we were authenticating with GitHub using the OctokitJS libary was deprecated so I updated that as well. 

Coverage is still high at ~95% and all new code is 100% covered. 

TODO: 

* [ ] Do the same check for before commenting on a closed PR to make sure it's been merged instead of just closed.