### PR TITLE
Remove Databox dashboard from Slackbot message

### DIFF
--- a/lib/templates/weeklyStats.hbs
+++ b/lib/templates/weeklyStats.hbs
@@ -1,5 +1,1 @@
 {{greeting}} We merged *{{ numberOfPullRequests }}* PR's this week, with an average merge time of *{{ averageMergeTime }} days*. {{#if longMergeTitle}} The PR <{{ longMergeURL }}|{{ longMergeTitle }}> took an unusually long amount of time to get merged ({{ longMergeTime }} days).{{/if}}
-
-Check out the live dashboard with more CesiumJS stats:
-
-https://app.databox.com/datawall/36dd3b071819692357099f6f52e6223205be31189


### PR DESCRIPTION
This makes Slackbot's weekly stats message slightly more concise. Since this databox link is always the last link, it gets expanded into a preview. I think it's not very useful since it's only for CesiumJS (it requires payment to aggregate multiple sources I think, plus we don't have as fine grained control over it as Slackbot's stats message). 

This will help because I think the next step is making Concierge watch more repo's, so it can be reporting how many PRs we've merged across all repo's. 