### PR TITLE
Trim words in corporate CLA check

### DIFF
--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -169,7 +169,6 @@ commentOnOpenedPullRequest._askForCla = function (userName) {
 
     var foundIndividualCLA = false;
     var foundCorporateCLA = false;
-
     // Check individual CLA sheet.
     return Settings.googleSheetsApi.spreadsheets.values.get({
         spreadsheetId: Settings.individualClaSheetID,
@@ -207,8 +206,8 @@ commentOnOpenedPullRequest._askForCla = function (userName) {
             rowScheduleA = rowScheduleA.replace(/\n/g, ' ');
             var words = rowScheduleA.split(' ');
             for (var j = 0; j < words.length; j++) {
-                if (userName.toLowerCase() === words[j]) {
-                    foundIndividualCLA = true;
+                if (userName.toLowerCase() === words[j].trim()) {
+                    foundCorporateCLA = true;
                     break;
                 }
             }


### PR DESCRIPTION
Concierge failed to look up a CLA that we know was in a corporate Schedule A (https://github.com/AnalyticalGraphicsInc/cesium/pull/8076#issuecomment-521684344). This was because the block of text returned from the Google Sheets API has extra control characters at the end that need to be trimmed before doing a string comparison. 

Tested this by running concierge locally with the corporate CLA spreadsheet to confirm it now correctly detects it. 

There was also a typo in that it was setting `foundIndividualCLA` regardless of whether it was the corporate or individual, but that doesn't change the returned result either way.